### PR TITLE
Remove toolchain and use plugin to have correct java and kotlin versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.maven.publish) apply false
     alias(libs.plugins.versions.catalogue.update)
+    alias(libs.plugins.compat.patrouille) apply false
 }
 
 versionCatalogUpdate {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,13 @@ android-compileSdk = "36"
 # @keep this version because it is not used in a dependency declaration
 android-minSdk = "24"
 assertk = "0.28.1"
+# @keep this is library java compatibility version
+java-version = "17"
 kotlin = "2.1.20"
+# @keep this is library kotlin compatibility version
+kotlin-version = "2.0.0"
 maven-publish-plugin = "0.31.0"
+patrouille-plugin = "0.0.0"
 versions-catalogue-update-plugin = "1.0.0"
 
 [libraries]
@@ -15,6 +20,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "agp" }
+compat-patrouille = { id = "com.gradleup.compat.patrouille", version.ref = "patrouille-plugin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish-plugin" }
 versions-catalogue-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "versions-catalogue-update-plugin" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -66,7 +66,14 @@ android {
     }
 }
 
-tasks.withType<JavaCompile>().configureEach { options.release.set(JvmTarget.JVM_17.target.toInt()) }
+tasks.withType<JavaCompile>().configureEach {
+    if (project.hasProperty("android")) {
+        sourceCompatibility = JavaVersion.VERSION_17.majorVersion
+        targetCompatibility = JavaVersion.VERSION_17.majorVersion
+    } else {
+        options.release.set(JvmTarget.JVM_17.target.toInt())
+    }
+}
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,32 +1,24 @@
 import com.vanniktech.maven.publish.SonatypeHost
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
+    alias(libs.plugins.compat.patrouille)
     alias(libs.plugins.maven.publish)
 }
 
 group = "nl.bijdorpstudio.kiban"
 version = "0.2.0"
 
-val javaVersion = JavaVersion.VERSION_17
-val jvmTargetVersion = JvmTarget.JVM_17
-val kotlinVersion = KotlinVersion.KOTLIN_1_9
+compatPatrouille {
+    java(libs.versions.java.version.get().toInt())
+    kotlin(libs.versions.kotlin.version.get())
+}
 
 kotlin {
-    jvm {
-        compilerOptions {
-            jvmTarget.set(jvmTargetVersion)
-            freeCompilerArgs.add("-Xjdk-release=${jvmTargetVersion.target}")
-        }
-    }
+    jvm()
     androidTarget {
         publishLibraryVariants("release")
-        compilerOptions {
-            jvmTarget.set(jvmTargetVersion)
-        }
     }
     iosX64()
     iosArm64()
@@ -38,13 +30,6 @@ kotlin {
             freeCompilerArgs.add("-XXLanguage:+JsAllowInvalidCharsIdentifiersEscaping") // Remove when target Kotlin 2.1+
         }
     }
-
-    compilerOptions {
-        apiVersion.set(kotlinVersion)
-        languageVersion.set(kotlinVersion)
-    }
-
-    coreLibrariesVersion = "${kotlinVersion.version}.0" // Kotlin versions have only major and minor without patch
 
     sourceSets {
         commonMain.dependencies {
@@ -63,19 +48,6 @@ android {
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    compileOptions {
-        sourceCompatibility = javaVersion
-        targetCompatibility = javaVersion
-    }
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    if (project.hasProperty("android")) {
-        sourceCompatibility = javaVersion.majorVersion
-        targetCompatibility = javaVersion.majorVersion
-    } else {
-        options.release.set(jvmTargetVersion.target.toInt())
     }
 }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -12,16 +12,16 @@ group = "nl.bijdorpstudio.kiban"
 version = "0.2.0"
 
 kotlin {
-    jvmToolchain(17)
     jvm {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
+            freeCompilerArgs.add("-Xjdk-release=${JvmTarget.JVM_17.target}")
         }
     }
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_11)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
     iosX64()
@@ -36,8 +36,11 @@ kotlin {
     }
 
     compilerOptions {
+        apiVersion.set(KotlinVersion.KOTLIN_1_9)
         languageVersion.set(KotlinVersion.KOTLIN_1_9)
     }
+
+    coreLibrariesVersion = "1.9.0"
 
     sourceSets {
         commonMain.dependencies {
@@ -58,10 +61,12 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
+
+tasks.withType<JavaCompile>().configureEach { options.release.set(JvmTarget.JVM_17.target.toInt()) }
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,17 +11,21 @@ plugins {
 group = "nl.bijdorpstudio.kiban"
 version = "0.2.0"
 
+val javaVersion = JavaVersion.VERSION_17
+val jvmTargetVersion = JvmTarget.JVM_17
+val kotlinVersion = KotlinVersion.KOTLIN_1_9
+
 kotlin {
     jvm {
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-            freeCompilerArgs.add("-Xjdk-release=${JvmTarget.JVM_17.target}")
+            jvmTarget.set(jvmTargetVersion)
+            freeCompilerArgs.add("-Xjdk-release=${jvmTargetVersion.target}")
         }
     }
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
+            jvmTarget.set(jvmTargetVersion)
         }
     }
     iosX64()
@@ -36,11 +40,11 @@ kotlin {
     }
 
     compilerOptions {
-        apiVersion.set(KotlinVersion.KOTLIN_1_9)
-        languageVersion.set(KotlinVersion.KOTLIN_1_9)
+        apiVersion.set(kotlinVersion)
+        languageVersion.set(kotlinVersion)
     }
 
-    coreLibrariesVersion = "1.9.0"
+    coreLibrariesVersion = "${kotlinVersion.version}.0" // Kotlin versions have only major and minor without patch
 
     sourceSets {
         commonMain.dependencies {
@@ -61,17 +65,17 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = javaVersion
+        targetCompatibility = javaVersion
     }
 }
 
 tasks.withType<JavaCompile>().configureEach {
     if (project.hasProperty("android")) {
-        sourceCompatibility = JavaVersion.VERSION_17.majorVersion
-        targetCompatibility = JavaVersion.VERSION_17.majorVersion
+        sourceCompatibility = javaVersion.majorVersion
+        targetCompatibility = javaVersion.majorVersion
     } else {
-        options.release.set(JvmTarget.JVM_17.target.toInt())
+        options.release.set(jvmTargetVersion.target.toInt())
     }
 }
 


### PR DESCRIPTION
## Changes
* Remove toolchain in favour of JDK release flag
* Add Kotlin API version
* Add kotlin sdk version
* Bump Android to JDK 17 also

All this because @MartinBonnin told us on Kotlin Conf today