### PR TITLE
Replace kotlinx.datetime.Instant with kotlin.time.Instant

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Obtain an `Iban` instance using one of the static factory methods: `valueOf( )` 
 ### Java IBAN library
 
 I [(Barend)](https://github.com/barend) like the Joda-Time library, and I try to follow the same design principles. I'm explicitly targetting Android, which at the time this library started was still on Java 1.6. I'm trying to keep the library as simple as I can.
-* Easy to integrate: don't bring transitive dependencies. **Note:** this is not true for KMP variant since Kotlin Time and Bignum dependencies added to keep orignal functionality.
+* Easy to integrate: don't bring transitive dependencies. The KMP variant follows this too: it depends only on the Kotlin standard library.
 * The `Iban` objects are immutable, and the Iban therein is non-empty and valid. There is no support for partial or invalid IBANs. Note that "valid" isn't as strict as it could be:
   * It checks that the length is correct (varies per country) and that the check digits are correct.
   * The national format mask (such as `QA2!n4!a21!c`) is not enforced. This seems to me like more work than necessary. The modulo-97 checksum catches most input errors anyway, and I don't want to force a memory-hungry regex check onto Android users. Speaking of Android, this mask could be used for keyboard switching on an Iban EditText, but that's for a different open-source project.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ assertk = "0.28.1"
 java-version = "17"
 kotlin = "2.3.10"
 kotlinx-binary-compatibility-validator = "0.17.0"
-kotlinx-datetime = "0.6.2"
 # @keep this is library kotlin compatibility version
 kotlin-version = "2.3.0"
 maven-publish-plugin = "0.36.0"
@@ -18,7 +17,6 @@ versions-catalogue-update-plugin = "1.0.1"
 
 [libraries]
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 [plugins]

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -6,7 +6,7 @@ public final class nl/bijdorpstudio/kiban/CountryCodes {
 	public final fun getBranchIdentifier (Lnl/bijdorpstudio/kiban/Iban;)Ljava/lang/String;
 	public final fun getKnownCountryCodes ()Ljava/util/Collection;
 	public final fun getLONGEST_IBAN_LENGTH ()I
-	public final fun getLastUpdateDate ()Lkotlinx/datetime/Instant;
+	public final fun getLastUpdateDate ()Lkotlin/time/Instant;
 	public final fun getLength (Ljava/lang/CharSequence;)Ljava/lang/Integer;
 	public final fun getLengthForCountryCode (Ljava/lang/CharSequence;)I
 	public final fun getSHORTEST_IBAN_LENGTH ()I

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -57,7 +57,7 @@ final object nl.bijdorpstudio.kiban/CountryCodes { // nl.bijdorpstudio.kiban/Cou
     final val knownCountryCodes // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes|{}knownCountryCodes[0]
         final fun <get-knownCountryCodes>(): kotlin.collections/Collection<kotlin/String> // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes.<get-knownCountryCodes>|<get-knownCountryCodes>(){}[0]
     final val lastUpdateDate // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate|{}lastUpdateDate[0]
-        final fun <get-lastUpdateDate>(): kotlinx.datetime/Instant // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate.<get-lastUpdateDate>|<get-lastUpdateDate>(){}[0]
+        final fun <get-lastUpdateDate>(): kotlin.time/Instant // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate.<get-lastUpdateDate>|<get-lastUpdateDate>(){}[0]
 
     final fun getBankIdentifier(nl.bijdorpstudio.kiban/Iban): kotlin/String? // nl.bijdorpstudio.kiban/CountryCodes.getBankIdentifier|getBankIdentifier(nl.bijdorpstudio.kiban.Iban){}[0]
     final fun getBranchIdentifier(nl.bijdorpstudio.kiban/Iban): kotlin/String? // nl.bijdorpstudio.kiban/CountryCodes.getBranchIdentifier|getBranchIdentifier(nl.bijdorpstudio.kiban.Iban){}[0]

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -29,10 +29,6 @@ kotlin {
     }
 
     sourceSets {
-        commonMain.dependencies {
-            implementation(libs.kotlinx.datetime)
-        }
-
         commonTest.dependencies {
             implementation(libs.assertk)
             implementation(libs.kotlin.test)

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
@@ -15,7 +15,7 @@
  */
 package nl.bijdorpstudio.kiban
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import nl.bijdorpstudio.kiban.CountryCodesData.BANK_CODE_BRANCH_CODE
 import nl.bijdorpstudio.kiban.CountryCodesData.BANK_IDENTIFIER_BEGIN_MASK
 import nl.bijdorpstudio.kiban.CountryCodesData.BANK_IDENTIFIER_END_MASK

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
@@ -21,8 +21,8 @@ import assertk.assertions.isBetween
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertFailsWith


### PR DESCRIPTION
Closes #48.

`CountryCodes.lastUpdateDate` now returns the stdlib `kotlin.time.Instant` instead of `kotlinx.datetime.Instant`, and the kotlinx-datetime dependency is removed entirely (version catalog + commonMain dependency). The test's `Clock.System` usage moves to `kotlin.time.Clock` likewise.

Result: **the library is dependency-free** — only the Kotlin standard library — restoring the original java-iban "no transitive dependencies" design principle (README note updated accordingly). It also decouples the public API from kotlinx-datetime's 0.7 breaking change, since the stdlib type is the one that ecosystem converged on.

Notes:
- No `@ExperimentalTime` opt-in needed — `kotlin.time.Instant`/`Clock` are stable at this project's Kotlin level.
- Breaking API change (return type), intentional while 0.x with no consumers; API dumps regenerated (`apiDump`), `apiCheck` passes.

## Verification

- `./gradlew jvmTest` passes
- `./gradlew apiCheck` passes against the regenerated dumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)