### PR TITLE
Result-based parse API with sealed error hierarchy

### DIFF
--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -41,10 +41,10 @@ public final class nl/bijdorpstudio/kiban/Iban : java/lang/Comparable {
 }
 
 public final class nl/bijdorpstudio/kiban/Iban$Companion {
-	public final fun compose (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
+	public final fun compose-gIAlu-s (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/Object;
 	public final fun format (Ljava/lang/CharSequence;)Ljava/lang/String;
-	public final fun invoke (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
-	public final fun parse (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
+	public final fun invoke-IoAF18A (Ljava/lang/CharSequence;)Ljava/lang/Object;
+	public final fun parse-IoAF18A (Ljava/lang/CharSequence;)Ljava/lang/Object;
 	public final fun toPlain (Ljava/lang/CharSequence;)Ljava/lang/String;
 	public final fun toPretty (Ljava/lang/CharSequence;)Ljava/lang/String;
 	public final fun valueOf (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
@@ -52,7 +52,45 @@ public final class nl/bijdorpstudio/kiban/Iban$Companion {
 
 public final class nl/bijdorpstudio/kiban/IbanKt {
 	public static final fun isValidIban (Ljava/lang/String;)Z
-	public static final fun toIban (Ljava/lang/String;)Lnl/bijdorpstudio/kiban/Iban;
+	public static final fun toIban (Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun toIbanOrNull (Ljava/lang/String;)Lnl/bijdorpstudio/kiban/Iban;
+}
+
+public abstract class nl/bijdorpstudio/kiban/IbanParseException : java/lang/IllegalArgumentException {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getInput ()Ljava/lang/String;
+}
+
+public final class nl/bijdorpstudio/kiban/IbanParseException$Malformed : nl/bijdorpstudio/kiban/IbanParseException {
+	public fun <init> (Ljava/lang/String;Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;Ljava/lang/String;)V
+	public final fun getKind ()Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+}
+
+public final class nl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind : java/lang/Enum {
+	public static final field EMPTY Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static final field INVALID_BOUNDARY_CHARACTER Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static final field INVALID_CHARACTER Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static final field INVALID_STRUCTURE Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static final field NON_NUMERIC_CHECK_DIGITS Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static final field TOO_SHORT Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static fun values ()[Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+}
+
+public final class nl/bijdorpstudio/kiban/IbanParseException$UnknownCountryCode : nl/bijdorpstudio/kiban/IbanParseException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getCountryCode ()Ljava/lang/String;
+}
+
+public final class nl/bijdorpstudio/kiban/IbanParseException$WrongChecksum : nl/bijdorpstudio/kiban/IbanParseException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class nl/bijdorpstudio/kiban/IbanParseException$WrongLength : nl/bijdorpstudio/kiban/IbanParseException {
+	public fun <init> (Ljava/lang/String;II)V
+	public final fun getActualLength ()I
+	public final fun getExpectedLength ()I
 }
 
 public final class nl/bijdorpstudio/kiban/Modulo97 {

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -34,13 +34,60 @@ final class nl.bijdorpstudio.kiban/Iban : kotlin/Comparable<nl.bijdorpstudio.kib
         final const val SHORTEST_POSSIBLE_IBAN // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN|{}SHORTEST_POSSIBLE_IBAN[0]
             final fun <get-SHORTEST_POSSIBLE_IBAN>(): kotlin/Int // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN.<get-SHORTEST_POSSIBLE_IBAN>|<get-SHORTEST_POSSIBLE_IBAN>(){}[0]
 
-        final fun compose(kotlin/CharSequence, kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.compose|compose(kotlin.CharSequence;kotlin.CharSequence){}[0]
+        final fun compose(kotlin/CharSequence, kotlin/CharSequence): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/Iban.Companion.compose|compose(kotlin.CharSequence;kotlin.CharSequence){}[0]
         final fun format(kotlin/CharSequence): kotlin/String // nl.bijdorpstudio.kiban/Iban.Companion.format|format(kotlin.CharSequence){}[0]
-        final fun invoke(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.invoke|invoke(kotlin.CharSequence){}[0]
-        final fun parse(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.parse|parse(kotlin.CharSequence){}[0]
+        final fun invoke(kotlin/CharSequence): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/Iban.Companion.invoke|invoke(kotlin.CharSequence){}[0]
+        final fun parse(kotlin/CharSequence): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/Iban.Companion.parse|parse(kotlin.CharSequence){}[0]
         final fun toPlain(kotlin/CharSequence): kotlin/String // nl.bijdorpstudio.kiban/Iban.Companion.toPlain|toPlain(kotlin.CharSequence){}[0]
         final fun toPretty(kotlin/CharSequence): kotlin/String // nl.bijdorpstudio.kiban/Iban.Companion.toPretty|toPretty(kotlin.CharSequence){}[0]
         final fun valueOf(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.valueOf|valueOf(kotlin.CharSequence){}[0]
+    }
+}
+
+sealed class nl.bijdorpstudio.kiban/IbanParseException : kotlin/IllegalArgumentException { // nl.bijdorpstudio.kiban/IbanParseException|null[0]
+    final val input // nl.bijdorpstudio.kiban/IbanParseException.input|{}input[0]
+        final fun <get-input>(): kotlin/String // nl.bijdorpstudio.kiban/IbanParseException.input.<get-input>|<get-input>(){}[0]
+
+    final class Malformed : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.Malformed|null[0]
+        constructor <init>(kotlin/String, nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind, kotlin/String) // nl.bijdorpstudio.kiban/IbanParseException.Malformed.<init>|<init>(kotlin.String;nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind;kotlin.String){}[0]
+
+        final val kind // nl.bijdorpstudio.kiban/IbanParseException.Malformed.kind|{}kind[0]
+            final fun <get-kind>(): nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind // nl.bijdorpstudio.kiban/IbanParseException.Malformed.kind.<get-kind>|<get-kind>(){}[0]
+
+        final enum class Kind : kotlin/Enum<nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind> { // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind|null[0]
+            enum entry EMPTY // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.EMPTY|null[0]
+            enum entry INVALID_BOUNDARY_CHARACTER // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER|null[0]
+            enum entry INVALID_CHARACTER // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.INVALID_CHARACTER|null[0]
+            enum entry INVALID_STRUCTURE // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.INVALID_STRUCTURE|null[0]
+            enum entry NON_NUMERIC_CHECK_DIGITS // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS|null[0]
+            enum entry TOO_SHORT // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.TOO_SHORT|null[0]
+
+            final val entries // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.entries|#static{}entries[0]
+                final fun <get-entries>(): kotlin.enums/EnumEntries<nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind> // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.entries.<get-entries>|<get-entries>#static(){}[0]
+
+            final fun valueOf(kotlin/String): nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.valueOf|valueOf#static(kotlin.String){}[0]
+            final fun values(): kotlin/Array<nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind> // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.values|values#static(){}[0]
+        }
+    }
+
+    final class UnknownCountryCode : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode|null[0]
+        constructor <init>(kotlin/String, kotlin/String) // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode.<init>|<init>(kotlin.String;kotlin.String){}[0]
+
+        final val countryCode // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode.countryCode|{}countryCode[0]
+            final fun <get-countryCode>(): kotlin/String // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode.countryCode.<get-countryCode>|<get-countryCode>(){}[0]
+    }
+
+    final class WrongChecksum : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.WrongChecksum|null[0]
+        constructor <init>(kotlin/String) // nl.bijdorpstudio.kiban/IbanParseException.WrongChecksum.<init>|<init>(kotlin.String){}[0]
+    }
+
+    final class WrongLength : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.WrongLength|null[0]
+        constructor <init>(kotlin/String, kotlin/Int, kotlin/Int) // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.<init>|<init>(kotlin.String;kotlin.Int;kotlin.Int){}[0]
+
+        final val actualLength // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.actualLength|{}actualLength[0]
+            final fun <get-actualLength>(): kotlin/Int // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.actualLength.<get-actualLength>|<get-actualLength>(){}[0]
+        final val expectedLength // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.expectedLength|{}expectedLength[0]
+            final fun <get-expectedLength>(): kotlin/Int // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.expectedLength.<get-expectedLength>|<get-expectedLength>(){}[0]
     }
 }
 
@@ -76,4 +123,5 @@ final object nl.bijdorpstudio.kiban/Modulo97 { // nl.bijdorpstudio.kiban/Modulo9
 }
 
 final fun (kotlin/String).nl.bijdorpstudio.kiban/isValidIban(): kotlin/Boolean // nl.bijdorpstudio.kiban/isValidIban|isValidIban@kotlin.String(){}[0]
-final fun (kotlin/String).nl.bijdorpstudio.kiban/toIban(): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/toIban|toIban@kotlin.String(){}[0]
+final fun (kotlin/String).nl.bijdorpstudio.kiban/toIban(): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/toIban|toIban@kotlin.String(){}[0]
+final fun (kotlin/String).nl.bijdorpstudio.kiban/toIbanOrNull(): nl.bijdorpstudio.kiban/Iban? // nl.bijdorpstudio.kiban/toIbanOrNull|toIbanOrNull@kotlin.String(){}[0]

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -15,8 +15,9 @@
  */
 package nl.bijdorpstudio.kiban
 
+import kotlin.Result.Companion.failure
 import nl.bijdorpstudio.kiban.Iban.Companion.parse
-import nl.bijdorpstudio.kiban.Iban.Companion.valueOf
+import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
 
 /**
  * An immutable value type representing an International Bank Account Number. Instances of this class have correct
@@ -25,11 +26,13 @@ import nl.bijdorpstudio.kiban.Iban.Companion.valueOf
  *
  * @author Barend Garvelink https://github.com/barend
  *
+ * Instances can only be obtained through [Iban.parse] or [Iban.compose], which validate the input and report failures
+ * as a [Result] carrying an [IbanParseException]. Construction itself never fails.
+ *
  * @property isInSwiftRegistry whether or not this IBAN data is from the SWIFT IBAN Registry.
  * @property isSEPA whether or not this IBAN is of a SEPA participating country.
  * @property plain the IBAN value, without any white space.
  * @property pretty the IBAN value, with spaces every four characters.
- * @throws [IllegalArgumentException] if the input is null, malformed or otherwise fails validation.
  * @since 1.0.0
  *
  * @see <a href="https://en.wikipedia.org/wiki/International_Bank_Account_Number">Wikipedia: International Bank Account Number</a>
@@ -55,29 +58,11 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
     val pretty: String by lazy(LazyThreadSafetyMode.NONE) { addSpaces(value) }
 
     /**
-     * Initializing constructor.
-     * @param value the IBAN value, without any white space.
-     * @throws [IllegalArgumentException] if the input is null, malformed or otherwise fails validation.
+     * Initializing constructor. Validation happens in [parse], so this constructor cannot fail.
+     * @param value the IBAN value, without any white space, already validated by [parse].
      */
     init {
-        if (value.length < SHORTEST_POSSIBLE_IBAN) {
-            throw IllegalArgumentException("Length is too short to be an IBAN: $value")
-        }
-        if (!(value[2].isDigit() && value[3].isDigit())) {
-            throw IllegalArgumentException("Characters at index 2 and 3 not both numeric. $value")
-        }
         val countryCode: String = value.substring(0, 2)
-        val expectedLength: Int? = CountryCodes.getLength(countryCode)
-        if (expectedLength == null) {
-            throw IllegalArgumentException("Unknown country code: $countryCode")
-        }
-        if (expectedLength != value.length) {
-            throw IllegalArgumentException("Wrong length ${value.length} for $value expected: $expectedLength")
-        }
-        val calculatedChecksum: Int = Modulo97.checksum(value)
-        if (calculatedChecksum != 1) {
-            throw IllegalArgumentException("Wrong check sum for $value")
-        }
         this.isInSwiftRegistry = CountryCodes.isInSwiftRegistry(countryCode)
         this.isSEPA = CountryCodes.isSEPACountry(countryCode)
     }
@@ -147,10 +132,10 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
         /**
          * Parses the given string into an IBAN object and confirms the check digits.
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
-         * @return the parsed and validated IBAN object
-         * @throws [IllegalArgumentException] if the input is in some way invalid.
+         * @return a [Result] holding the parsed and validated IBAN object, or an [IbanParseException] describing why the input was rejected.
+         * @see [parse]
          */
-        operator fun invoke(input: CharSequence): Iban = parse(input)
+        operator fun invoke(input: CharSequence): Result<Iban> = parse(input)
 
         /**
          * The technically shortest possible IBAN. See [CountryCodes.SHORTEST_IBAN_LENGTH] for the shortest valid length.
@@ -159,47 +144,101 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
 
         /**
          * Parses the given string into an IBAN object and confirms the check digits.
+         *
+         * This is the primary entry point of the library. It never throws for invalid user input; failures are returned
+         * as a [Result.failure] carrying an [IbanParseException]. Use [Result.getOrThrow] for the semantics of the
+         * deprecated throwing API.
+         *
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
-         * @return the parsed and validated IBAN object
-         * @throws [IllegalArgumentException] if the input is in some way invalid.
-         * @see [valueOf]
+         * @return a [Result] holding the parsed and validated IBAN object, or an [IbanParseException] describing why the input was rejected.
+         * @see [IbanParseException]
          */
-        fun parse(input: CharSequence): Iban {
+        fun parse(input: CharSequence): Result<Iban> {
             if (input.isEmpty()) {
-                throw IllegalArgumentException("Input is empty")
+                return failure(IbanParseException.Malformed("", Kind.EMPTY, "Input is empty"))
             }
             if (!input.first().isLetterOrDigit() || !input.last().isLetterOrDigit()) {
-                throw IllegalArgumentException("Input begins or ends in an invalid character: $input")
+                return failure(
+                    IbanParseException.Malformed(
+                        toPlain(input),
+                        Kind.INVALID_BOUNDARY_CHARACTER,
+                        "Input begins or ends in an invalid character: $input"
+                    )
+                )
             }
-            return Iban(toPlain(input))
+            val value = toPlain(input)
+            if (value.length < SHORTEST_POSSIBLE_IBAN) {
+                return failure(
+                    IbanParseException.Malformed(
+                        value,
+                        Kind.TOO_SHORT,
+                        "Length is too short to be an IBAN: $value"
+                    )
+                )
+            }
+            if (!(value[2].isDigit() && value[3].isDigit())) {
+                return failure(
+                    IbanParseException.Malformed(
+                        value,
+                        Kind.NON_NUMERIC_CHECK_DIGITS,
+                        "Characters at index 2 and 3 not both numeric. $value"
+                    )
+                )
+            }
+            val countryCode: String = value.substring(0, 2)
+            val expectedLength: Int = CountryCodes.getLength(countryCode)
+                ?: return failure(IbanParseException.UnknownCountryCode(value, countryCode))
+            if (expectedLength != value.length) {
+                return failure(IbanParseException.WrongLength(value, expectedLength, value.length))
+            }
+            val calculatedChecksum: Int = try {
+                Modulo97.checksum(value)
+            } catch (e: IllegalArgumentException) {
+                return failure(
+                    IbanParseException.Malformed(
+                        value,
+                        Kind.INVALID_CHARACTER,
+                        e.message ?: "Invalid character in $value"
+                    )
+                )
+            }
+            if (calculatedChecksum != 1) {
+                return failure(IbanParseException.WrongChecksum(value))
+            }
+            return Result.success(Iban(value))
         }
 
         /**
-         * Parses the given string into an IBAN object and confirms the check digits, but returns null for null.
+         * Parses the given string into an IBAN object and confirms the check digits, throwing on invalid input.
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted ("CC11 ABCD 123. ..").
          * @return the parsed and validated IBAN object.
          * @throws [IllegalArgumentException] if the input is in some way invalid.
          * @see [parse]
          */
         @Deprecated("Use parse() instead", ReplaceWith("parse(input)"))
-        fun valueOf(input: CharSequence): Iban = parse(input)
+        fun valueOf(input: CharSequence): Iban = parse(input).getOrThrow()
 
         /**
-         * Composes an IBAN from the given country code and basic bank account number.
+         * Composes an IBAN from the given country code and basic bank account number, calculating the check digits.
          * @param countryCode the country code.
          * @param bban the BBAN.
-         * @return an IBAN object composed of the given parts, if valid.
-         * @throws [IllegalArgumentException] if the input is in some way invalid.
+         * @return a [Result] holding the IBAN object composed of the given parts, or an [IbanParseException] describing why the parts were rejected.
          */
-        fun compose(countryCode: CharSequence, bban: CharSequence): Iban {
+        fun compose(countryCode: CharSequence, bban: CharSequence): Result<Iban> {
             val sb = StringBuilder(CountryCodes.LONGEST_IBAN_LENGTH).append(countryCode).append("00").append(bban)
-            val checkDigits = Modulo97.calculateCheckDigits(sb)
-            if (checkDigits < 10) {
-                sb[3] = ('0'.code + checkDigits).toChar()
-            } else {
-                sb.replaceRange(2..3, checkDigits.toString())
+            val checkDigits = try {
+                Modulo97.calculateCheckDigits(sb)
+            } catch (e: IllegalArgumentException) {
+                return failure(
+                    IbanParseException.Malformed(
+                        toPlain(sb),
+                        Kind.INVALID_STRUCTURE,
+                        e.message ?: "Cannot calculate check digits for $sb"
+                    )
+                )
             }
-            return parse(sb.toString())
+            sb.setRange(2, 4, checkDigits.toString().padStart(2, '0'))
+            return parse(sb)
         }
 
         /**
@@ -252,19 +291,19 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
 
 /**
  * Parses the given string into an IBAN object and confirms the check digits.
- * @return the parsed and validated IBAN object
- * @throws [IllegalArgumentException] if the input is in some way invalid.
+ * @return a [Result] holding the parsed and validated IBAN object, or an [IbanParseException] describing why the input was rejected.
  * @see Iban.parse
  */
-fun String.toIban(): Iban = Iban.parse(this)
+fun String.toIban(): Result<Iban> = Iban.parse(this)
+
+/**
+ * Parses the given string into an IBAN object and confirms the check digits, discarding the failure detail.
+ * @return the parsed and validated IBAN object, or `null` if the input is in some way invalid.
+ * @see Iban.parse
+ */
+fun String.toIbanOrNull(): Iban? = Iban.parse(this).getOrNull()
 
 /**
  * Returns whether the given string is a valid IBAN.
  */
-fun String.isValidIban(): Boolean =
-    try {
-        Iban.parse(this)
-        true
-    } catch (e: IllegalArgumentException) {
-        false
-    }
+fun String.isValidIban(): Boolean = Iban.parse(this).isSuccess

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -1,0 +1,99 @@
+/*
+   Copyright 2026 Barend Garvelink, Eugen Martynov
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package nl.bijdorpstudio.kiban
+
+/**
+ * The failure carried by the [Result] of a failed [Iban.parse] or [Iban.compose].
+ *
+ * Instances are never thrown by the library itself; they are wrapped in [Result.failure] so that callers can decide
+ * whether to inspect the failure or to rethrow it with [Result.getOrThrow]. Extending [IllegalArgumentException] keeps
+ * the semantics of the deprecated throwing API identical.
+ *
+ * @property input the offending input, with any white space removed.
+ */
+sealed class IbanParseException(
+    val input: String,
+    message: String
+) : IllegalArgumentException(message) {
+
+    /**
+     * The input is not shaped like an IBAN at all: it is empty, too short, contains unsupported characters or does not
+     * carry numeric check digits.
+     *
+     * @property kind the specific structural problem detected.
+     */
+    class Malformed(
+        input: String,
+        val kind: Kind,
+        message: String
+    ) : IbanParseException(input, message) {
+
+        /**
+         * The structural problem that made the input malformed.
+         */
+        enum class Kind {
+            /** The input is empty. */
+            EMPTY,
+
+            /** The input begins or ends in a character that cannot occur in an IBAN. */
+            INVALID_BOUNDARY_CHARACTER,
+
+            /** The input is shorter than [Iban.SHORTEST_POSSIBLE_IBAN]. */
+            TOO_SHORT,
+
+            /** The characters at index 2 and 3 are not both numeric. */
+            NON_NUMERIC_CHECK_DIGITS,
+
+            /** The input contains a character outside the range `[A-Za-z0-9 ]`. */
+            INVALID_CHARACTER,
+
+            /**
+             * The parts handed to [Iban.compose] cannot be assembled into an IBAN, because they are too short, carry
+             * unsupported characters, or because the country code is not exactly two characters.
+             */
+            INVALID_STRUCTURE
+        }
+    }
+
+    /**
+     * The country code of the input is not a known IBAN country code.
+     *
+     * @property countryCode the two-letter country code that was not recognized.
+     */
+    class UnknownCountryCode(
+        input: String,
+        val countryCode: String
+    ) : IbanParseException(input, "Unknown country code: $countryCode")
+
+    /**
+     * The input has a valid country code, but its length does not match the length registered for that country.
+     *
+     * @property expectedLength the length registered for the country code of the input.
+     * @property actualLength the length of the input.
+     */
+    class WrongLength(
+        input: String,
+        val expectedLength: Int,
+        val actualLength: Int
+    ) : IbanParseException(input, "Wrong length $actualLength for $input expected: $expectedLength")
+
+    /**
+     * The input is structurally valid, but fails MOD-97 check digit verification.
+     */
+    class WrongChecksum(
+        input: String
+    ) : IbanParseException(input, "Wrong check sum for $input")
+}

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldTest.kt
@@ -29,7 +29,7 @@ class CountryCodesIbanFieldsTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                val iban = Iban.parse(td.plain)
+                val iban = Iban.parse(td.plain).getOrThrow()
                 assertThat(CountryCodes.getBankIdentifier(iban)).isEqualTo(td.bank)
             }
     }
@@ -39,7 +39,7 @@ class CountryCodesIbanFieldsTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                val iban = Iban.parse(td.plain)
+                val iban = Iban.parse(td.plain).getOrThrow()
                 assertThat(CountryCodes.getBranchIdentifier(iban)).isEqualTo(td.branch)
             }
     }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
@@ -28,7 +28,7 @@ class IbanInternationalTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { testData ->
-                val iban = Iban.parse(testData.plain)
+                val iban = Iban.parse(testData.plain).getOrThrow()
                 assertThat(iban.toPlainString()).isEqualTo(testData.plain)
                 assertThat(iban.toString()).isEqualTo(testData.pretty)
             }
@@ -39,9 +39,22 @@ class IbanInternationalTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                val iban = Iban.parse(td.pretty)
+                val iban = Iban.parse(td.pretty).getOrThrow()
                 assertThat(iban.toPlainString()).isEqualTo(td.plain)
                 assertThat(iban.toString()).isEqualTo(td.pretty)
+            }
+    }
+
+    @Test
+    fun `Compose should round trip every country`() {
+        CountryCodesParameterizedTest
+            .countriesTestDataTable
+            .forAll { td ->
+                val composed = Iban.compose(
+                    countryCode = td.plain.substring(0, 2),
+                    bban = td.plain.substring(4)
+                )
+                assertThat(composed.getOrThrow()).isEqualTo(Iban.parse(td.plain).getOrThrow())
             }
     }
 
@@ -50,7 +63,7 @@ class IbanInternationalTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                assertThat(Iban.parse(td.plain).isInSwiftRegistry).isEqualTo(td.swift)
+                assertThat(Iban.parse(td.plain).getOrThrow().isInSwiftRegistry).isEqualTo(td.swift)
             }
     }
 
@@ -59,7 +72,7 @@ class IbanInternationalTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                assertThat(Iban.parse(td.plain).isSEPA).isEqualTo(td.sepa)
+                assertThat(Iban.parse(td.plain).getOrThrow().isSEPA).isEqualTo(td.sepa)
             }
     }
 

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -20,12 +20,13 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
 import assertk.tableOf
 import kotlin.test.Test
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 
 
 /**
@@ -34,14 +35,31 @@ import kotlin.test.assertFailsWith
 class IbanTest {
     @Test
     fun `Operator invoke should parse IBAN`() {
-        val iban = Iban(VALID_IBAN)
+        // Called through the companion explicitly: inside the library module the internal constructor would win.
+        val iban = Iban.Companion.invoke(VALID_IBAN).getOrThrow()
         assertThat(iban.plain).isEqualTo(VALID_IBAN)
     }
 
     @Test
     fun `toIban extension should parse IBAN`() {
-        val iban = VALID_IBAN.toIban()
+        val iban = VALID_IBAN.toIban().getOrThrow()
         assertThat(iban.plain).isEqualTo(VALID_IBAN)
+    }
+
+    @Test
+    fun `toIban extension should return failure for invalid IBAN`() {
+        assertThat(INVALID_IBAN.toIban().failure())
+            .isInstanceOf<IbanParseException.WrongChecksum>()
+    }
+
+    @Test
+    fun `toIbanOrNull extension should parse IBAN`() {
+        assertThat(VALID_IBAN.toIbanOrNull()?.plain).isEqualTo(VALID_IBAN)
+    }
+
+    @Test
+    fun `toIbanOrNull extension should return null for invalid IBAN`() {
+        assertThat(INVALID_IBAN.toIbanOrNull()).isNull()
     }
 
     @Test
@@ -56,64 +74,106 @@ class IbanTest {
 
     @Test
     fun `Valid IBAN should return country code`() {
-        assertThat(Iban.parse(VALID_IBAN).countryCode).isEqualTo("NL")
+        assertThat(Iban.parse(VALID_IBAN).getOrThrow().countryCode).isEqualTo("NL")
     }
 
     @Test
     fun `Valid IBAN should return check digits`() {
-        assertThat(Iban.parse(VALID_IBAN).checkDigits).isEqualTo("03")
+        assertThat(Iban.parse(VALID_IBAN).getOrThrow().checkDigits).isEqualTo("03")
     }
 
     @Test
     fun `valueOf should accept toString output of valid IBAN`() {
-        val original = Iban.parse(VALID_IBAN)
+        val original = Iban.parse(VALID_IBAN).getOrThrow()
         val copy = Iban.valueOf(original.toString())
         assertThat(copy).isEqualTo(original)
     }
 
     @Test
-    fun `Parse should reject invalid input`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.parse("Shenanigans!")
+    fun `valueOf should throw for invalid input`() {
+        assertFailsWith<IbanParseException.WrongChecksum> {
+            Iban.valueOf(INVALID_IBAN)
         }
+    }
+
+    @Test
+    fun `Parse should reject empty input`() {
+        assertThat(Iban.parse("").malformedKind()).isEqualTo(IbanParseException.Malformed.Kind.EMPTY)
+    }
+
+    @Test
+    fun `Parse should reject invalid input`() {
+        assertThat(Iban.parse("Shenanigans!").malformedKind())
+            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
     }
 
     @Test
     fun `Parse should reject leading whitespace`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.parse(" $VALID_IBAN")
-        }
+        assertThat(Iban.parse(" $VALID_IBAN").malformedKind())
+            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
     }
 
     @Test
     fun `Parse should reject trailing whitespace`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.parse("$VALID_IBAN ")
-        }
+        assertThat(Iban.parse("$VALID_IBAN ").malformedKind())
+            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+    }
+
+    @Test
+    fun `Parse should reject too short input`() {
+        assertThat(Iban.parse("NL03").malformedKind()).isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
+    }
+
+    @Test
+    fun `Parse should reject non numeric check digits`() {
+        assertThat(Iban.parse("NLAB0143267469").malformedKind())
+            .isEqualTo(IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS)
+    }
+
+    @Test
+    fun `Parse should reject unsupported characters`() {
+        val invalidCharacter = VALID_IBAN.replaceRange(6, 7, "_")
+
+        assertThat(Iban.parse(invalidCharacter).malformedKind())
+            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
     }
 
     @Test
     fun `Parse should reject unknown country code`() {
-        val exception = assertFails {
-            Iban.parse("UU345678345543234")
-        }
+        val failure = Iban.parse("UU345678345543234").failure()
 
-        assertThat(exception)
-            .isInstanceOf<IllegalArgumentException>()
-            .prop(IllegalArgumentException::message)
-            .isEqualTo("Unknown country code: UU")
+        assertThat(failure)
+            .isInstanceOf<IbanParseException.UnknownCountryCode>()
+            .prop(IbanParseException.UnknownCountryCode::countryCode)
+            .isEqualTo("UU")
+        assertThat(failure.message).isEqualTo("Unknown country code: UU")
+    }
+
+    @Test
+    fun `Parse should reject wrong length`() {
+        val tooLong = VALID_IBAN + "0"
+
+        assertThat(Iban.parse(tooLong).failure())
+            .isInstanceOf<IbanParseException.WrongLength>()
+            .prop(IbanParseException.WrongLength::expectedLength)
+            .isEqualTo(18)
     }
 
     @Test
     fun `Parse should reject checksum failure`() {
-        val exception = assertFails {
-            Iban.parse(INVALID_IBAN)
-        }
+        val failure = Iban.parse(INVALID_IBAN).failure()
 
-        assertThat(exception)
+        assertThat(failure)
+            .isInstanceOf<IbanParseException.WrongChecksum>()
+            .prop(IbanParseException.WrongChecksum::input)
+            .isEqualTo(INVALID_IBAN)
+        assertThat(failure.message).isEqualTo("Wrong check sum for $INVALID_IBAN")
+    }
+
+    @Test
+    fun `Parse failure should be an IllegalArgumentException`() {
+        assertThat(Iban.parse(INVALID_IBAN).failure())
             .isInstanceOf<IllegalArgumentException>()
-            .prop(IllegalArgumentException::message)
-            .isEqualTo("Wrong check sum for $INVALID_IBAN")
     }
 
     @Test
@@ -122,54 +182,45 @@ class IbanTest {
             countryCode = VALID_IBAN.substring(0, 2),
             bban = VALID_IBAN.substring(4)
         )
-        assertThat(composed).isEqualTo(Iban.parse(VALID_IBAN))
+        assertThat(composed.getOrThrow()).isEqualTo(Iban.parse(VALID_IBAN).getOrThrow())
+    }
+
+    @Test
+    fun `Compose should handle check digits of ten and higher`() {
+        val composed = Iban.compose(countryCode = "BI", bban = "10000100010000332045181")
+
+        assertThat(composed.getOrThrow().plain).isEqualTo("BI4210000100010000332045181")
     }
 
     @Test
     fun `Compose should reject blank country code`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.compose(
-                countryCode = "  ",
-                bban = VALID_IBAN.substring(4)
-            )
-        }
+        assertThat(Iban.compose(countryCode = "  ", bban = VALID_IBAN.substring(4)).failure())
+            .isInstanceOf<IbanParseException>()
     }
 
     @Test
     fun `Compose should reject malformed country code`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.compose(
-                countryCode = "potato",
-                bban = VALID_IBAN.substring(4)
-            )
-        }
+        assertThat(Iban.compose(countryCode = "potato", bban = VALID_IBAN.substring(4)).malformedKind())
+            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_STRUCTURE)
     }
 
     @Test
     fun `Compose should reject unknown country code`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.compose(
-                countryCode = "XX",
-                bban = VALID_IBAN.substring(4)
-            )
-        }
+        assertThat(Iban.compose(countryCode = "XX", bban = VALID_IBAN.substring(4)).failure())
+            .isInstanceOf<IbanParseException.UnknownCountryCode>()
     }
 
     @Test
     fun `Compose should reject wrong length BBAN`() {
-        assertFailsWith<IllegalArgumentException> {
-            Iban.compose(
-                countryCode = VALID_IBAN.substring(0, 2),
-                bban = VALID_IBAN.substring(5)
-            )
-        }
+        assertThat(Iban.compose(countryCode = VALID_IBAN.substring(0, 2), bban = VALID_IBAN.substring(5)).failure())
+            .isInstanceOf<IbanParseException.WrongLength>()
     }
 
     @Test
     fun `Equals contract should be satisfied`() {
-        val x = Iban.parse(VALID_IBAN)
-        val y = Iban.parse(VALID_IBAN)
-        val z = Iban.parse(VALID_IBAN)
+        val x = Iban.parse(VALID_IBAN).getOrThrow()
+        val y = Iban.parse(VALID_IBAN).getOrThrow()
+        val z = Iban.parse(VALID_IBAN).getOrThrow()
 
         assertThat(x, "An object is not equal to nul").isNotEqualTo(null)
         assertThat(x, "An object equals itself").isEqualTo(x)
@@ -220,14 +271,14 @@ class IbanTest {
     @Test
     fun `Lexical sort should order IBANs correctly`() {
         val expected = listOf(
-            Iban.parse("DK3400000000000003"),
-            Iban.parse("NL41BANK0000000002"),
-            Iban.parse("NL68BANK0000000001")
+            Iban.parse("DK3400000000000003").getOrThrow(),
+            Iban.parse("NL41BANK0000000002").getOrThrow(),
+            Iban.parse("NL68BANK0000000001").getOrThrow()
         )
         val actual = listOf(
-            Iban.parse("NL68BANK0000000001"),
-            Iban.parse("DK3400000000000003"),
-            Iban.parse("NL41BANK0000000002")
+            Iban.parse("NL68BANK0000000001").getOrThrow(),
+            Iban.parse("DK3400000000000003").getOrThrow(),
+            Iban.parse("NL41BANK0000000002").getOrThrow()
         )
 
         assertThat(actual.sorted()).isEqualTo(expected)
@@ -236,5 +287,11 @@ class IbanTest {
     companion object {
         internal const val VALID_IBAN = "NL03ABNA0143267469"
         private const val INVALID_IBAN = "NL13ABNA0143267469"
+
+        private fun Result<Iban>.failure(): Throwable =
+            exceptionOrNull() ?: fail("Expected a failure, but was $this")
+
+        private fun Result<Iban>.malformedKind(): IbanParseException.Malformed.Kind? =
+            (exceptionOrNull() as? IbanParseException.Malformed)?.kind
     }
 }

--- a/library/src/jvmTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldsTest.kt
+++ b/library/src/jvmTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldsTest.kt
@@ -13,7 +13,7 @@ class IbanFieldsTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                val iban = Iban.parse(td.plain)
+                val iban = Iban.parse(td.plain).getOrThrow()
                 val bankIdentifier = IBANFields.getBankIdentifier(iban)
                 assertThat(bankIdentifier).isNotNull()
                 if (td.bank == null) {
@@ -29,7 +29,7 @@ class IbanFieldsTest {
         CountryCodesParameterizedTest
             .countriesTestDataTable
             .forAll { td ->
-                val iban = Iban.parse(td.plain)
+                val iban = Iban.parse(td.plain).getOrThrow()
                 val branchIdentifier = IBANFields.getBranchIdentifier(iban)
                 assertThat(branchIdentifier).isNotNull()
                 if (td.branch == null) {


### PR DESCRIPTION
Closes #46. Also closes #45 — the `Iban.compose` bug is fixed here, since #46 rewrites `compose` anyway.

## API shape

- `Iban.parse(input: CharSequence): Result<Iban>` — primary entry point (breaking change)
- `Iban.compose(countryCode, bban): Result<Iban>`
- `Iban.Companion.invoke(input): Result<Iban>` follows `parse`
- `String.toIban(): Result<Iban>`, new `String.toIbanOrNull(): Iban?`, `String.isValidIban(): Boolean` (now `parse(this).isSuccess`)
- `Iban.valueOf` stays deprecated and throwing, implemented as `parse(input).getOrThrow()`

Failures are `Result.failure` carrying a sealed hierarchy that the library itself never throws:

```kotlin
sealed class IbanParseException(val input: String, message: String) : IllegalArgumentException(message) {
    class Malformed(input, val kind: Kind, message)   // EMPTY, INVALID_BOUNDARY_CHARACTER, TOO_SHORT,
                                                      // NON_NUMERIC_CHECK_DIGITS, INVALID_CHARACTER,
                                                      // INVALID_STRUCTURE
    class UnknownCountryCode(input, val countryCode: String)
    class WrongLength(input, val expectedLength: Int, val actualLength: Int)
    class WrongChecksum(input)
}
```

Extending `IllegalArgumentException` keeps `getOrThrow()` semantics identical to the old throwing API. Existing failure messages are preserved verbatim, so anything matching on them still works.

Notes on the two places the issue left open:

- `Malformed.Kind` gives callers a typed reason without parsing messages. `INVALID_STRUCTURE` covers the one failure mode that only `compose` can produce — parts that cannot be assembled into an IBAN at all, e.g. a country code that isn't two characters.
- Validation moved out of the `Iban` `init` block into `parse`, so construction cannot fail. `Modulo97` stays throwing as agreed; `parse` and `compose` catch its contract violations and translate them into `Malformed` failures rather than letting them escape.

## Fix for #45

`compose` used the non-mutating `CharSequence.replaceRange` extension, so the discarded result left `00` at indices 2–3 and every IBAN with check digits >= 10 failed checksum validation. Replaced with the mutating `setRange(2, 4, checkDigits.toString().padStart(2, '0'))`, which handles both branches, so the `< 10` special case is gone.

## Tests

- Per-country `compose` round trip over the full country table (`compose(countryCode, bban) == parse(plain)`), which exercises both check-digit branches for every country — this is the test gap called out in #45
- Explicit two-digit check-digit case (BI, check digits 42)
- One test per failure type and per `Malformed.Kind`, including the new `INVALID_STRUCTURE`
- `toIban` failure, `toIbanOrNull` both ways, `valueOf` still throwing
- Existing call sites updated to `.getOrThrow()`

## Verification

- `./gradlew jvmTest` passes
- API dumps regenerated for both the JVM and klib targets and committed

Note on how the dumps were produced: this sandbox's egress policy denies `dl.google.com` and the Kotlin/Native distribution host, so Gradle could not resolve AGP or build the native targets. I temporarily disabled the Android and native targets locally to run the build, generated the klib dump from the `js` target — all sources are `commonMain`, so the dump body is target-independent — and restored the `// Targets:` header by hand. The regenerated dumps were then diffed against the committed ones to confirm they match exactly. The build files are unmodified in this PR, but `apiCheck` has not run against the real target set, so please let CI confirm it.

One thing deliberately left out of scope: the `ReplaceWith` targets on the deprecated shims still point at the old API, and README examples still show the throwing API. #47 and #51 cover those.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fU2nRFSCBaAHnp7Ms5TLb)_