### PR TITLE
CI hygiene: run tests before publish, replace deprecated gradle-build-action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.konan
@@ -55,6 +55,4 @@ jobs:
         cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
-      with:
-        arguments: ${{ matrix.target }}
+      run: ./gradlew ${{ matrix.target }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,15 @@ on:
   release:
     types: [released, prereleased]
 jobs:
+  # Run the full check matrix (tests on every target plus apiCheck) before publishing anything.
+  test:
+    name: Check
+    uses: ./.github/workflows/gradle.yml
+    secrets: inherit
+
   publish:
     name: Release build and publish
+    needs: test
     runs-on: macOS-latest
     steps:
       - name: Check out code
@@ -25,9 +32,6 @@ jobs:
           # Builds on other branches will only read existing entries from the cache.
           cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/release' }}
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-      - name: API Check
-        run: ./gradlew apiCheck
 
       - name: Publish to MavenCentral
         run: ./gradlew publishToMavenCentral --no-configuration-cache


### PR DESCRIPTION
Closes #52.

## Tests before publish

`publish.yml` previously ran only `apiCheck` before `publishToMavenCentral`, so a release could ship code whose tests were never run on the release commit. It now calls `gradle.yml` through that workflow's existing `workflow_call` trigger:

```yaml
jobs:
  test:
    name: Check
    uses: ./.github/workflows/gradle.yml
    secrets: inherit

  publish:
    needs: test
```

That runs the full matrix — `jvmTest`, `jsTest`, `linuxX64Test`, `iosSimulatorArm64Test`, `apiCheck`, and the Android assemble — and `needs: test` gates publishing on all of it. `secrets: inherit` is required so the called workflow still gets `GRADLE_ENCRYPTION_KEY` for its Gradle cache.

The standalone `API Check` step is removed from `publish.yml`, since `apiCheck` is already one of the matrix entries and running it twice buys nothing.

## Deprecated actions

- `gradle/gradle-build-action` (pinned SHA) replaced with `run: ./gradlew ${{ matrix.target }}`. `gradle/actions/setup-gradle@v4` was already in the job doing the caching and wrapper setup, so the second action was both redundant and deprecated. Word splitting handles the one multi-task matrix entry (`assembleAndroidMain androidCompileLintChecks`) exactly as the old `arguments:` input did.
- `actions/cache@v3` → `@v4` for the `~/.konan` cache. Slightly beyond the issue's two bullets, but v3 is deprecated and this is the same class of change — drop this line if you'd rather keep the PR to the letter of the issue.

## Verification

Both workflow files parse, and the resulting job graphs are `gradle.yml -> [build]` and `publish.yml -> [test, publish]`. Beyond that this change is only exercisable by GitHub Actions itself: the `gradle.yml` matrix runs on this PR and proves the `./gradlew` invocation works, but the `publish.yml` path only runs on a release event, so its first real exercise will be the 0.4.0 release. The reuse is a plain `uses:` on a workflow that already declares `workflow_call`, which is why I'm comfortable proposing it unexercised — but it is worth knowing it hasn't run.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fU2nRFSCBaAHnp7Ms5TLb)_