### PR TITLE
Expand KMP target matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,12 +19,25 @@ jobs:
         include:
           - target: iosSimulatorArm64Test
             os: macos-latest
+          - target: macosArm64Test
+            os: macos-latest
+          - target: tvosSimulatorArm64Test
+            os: macos-latest
+          - target: watchosSimulatorArm64Test
+            os: macos-latest
           - target: jvmTest
             os: ubuntu-latest
           - target: linuxX64Test
             os: ubuntu-latest
           - target: jsTest
             os: ubuntu-latest
+          - target: wasmJsTest
+            os: ubuntu-latest
+          # Targets with no runner to execute on: cross-compile only.
+          - target: compileKotlinLinuxArm64 compileKotlinMingwX64
+            os: ubuntu-latest
+          # apiCheck builds a klib for every target the host supports, so it
+          # doubles as the compile check for the Apple targets.
           - target: apiCheck
             os: macos-latest
           - target: assembleAndroidMain androidCompileLintChecks

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.kotlin.multiplatform.library)
@@ -23,9 +25,38 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+    tvosX64()
+    tvosArm64()
+    tvosSimulatorArm64()
+    watchosX64()
+    watchosArm64()
+    watchosDeviceArm64()
+    watchosSimulatorArm64()
     linuxX64()
+    linuxArm64()
+    mingwX64()
     js(IR) {
         nodejs()
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                }
+            }
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Closes #50.

**Stacked on #57** — both PRs edit `gradle.yml`, so this one targets that branch instead of `main` to avoid a conflict. Merge #57 first and GitHub will retarget this to `main` automatically. The diff here is only this issue's changes.

## Targets added

| Group | Added |
| --- | --- |
| Apple | `macosX64`, `macosArm64`, `tvosX64`, `tvosArm64`, `tvosSimulatorArm64`, `watchosX64`, `watchosArm64`, `watchosDeviceArm64`, `watchosSimulatorArm64` |
| Other native | `linuxArm64`, `mingwX64` |
| Web | `wasmJs` (nodejs + browser), and `browser()` added to the existing `js` target |

`watchosDeviceArm64` is the "device variant as appropriate" from the issue — `watchosArm64` is the arm64_32 device target, so this covers the newer arm64 watch devices.

Browser test tasks pin `useChromeHeadless()` explicitly instead of relying on the Karma default, since I couldn't exercise that path locally (see below).

## CI matrix

Added `macosArm64Test`, `tvosSimulatorArm64Test`, `watchosSimulatorArm64Test` (macOS runner) and `wasmJsTest` (Ubuntu). `linuxArm64` and `mingwX64` have no runner to execute on, so they get a cross-compile check — `compileKotlinLinuxArm64 compileKotlinMingwX64` — as the issue suggested. The remaining Apple targets are covered for compilation by the `apiCheck` job, which builds a klib for every target the host supports.

## API dump

The `Targets` header now lists all 17 klib targets; the ABI body is byte-identical because every declaration lives in `commonMain`.

**How that was produced, since it matters for review.** This sandbox's egress policy blocks the Kotlin/Native distribution host, so I can't build native targets here and can't run `apiDump` for real. I generated a dump with only `js` and `wasmJs` declared — which needs no Konan — confirmed its body is byte-identical to the one on `main`, took BCV's own spelling of `wasmJs` from that output, and wrote the full target list into the header sorted the way BCV sorts it. Adding a target only changes that header when no declaration is target-specific, which is the case here.

The residual risk is the header itself: if BCV renders the list differently than I predicted, `apiCheck` fails and I'll fix it from the CI output. Note that `klibApiExtractForValidation` strips host-unsupported targets from the golden file before comparing, so listing targets the macOS runner can't build is safe by design.

## Verification

Run locally:

- Build script configures with all 17 targets — `outgoingVariants` shows a variant per target, including `library-wasm-js-0.3.0.klib`, so the `ExperimentalWasmDsl` opt-in and import path are right
- All the new Gradle tasks this PR relies on exist: `jsBrowserTest`, `wasmJsBrowserTest`, `macosArm64Test`, `tvosSimulatorArm64Test`, `watchosSimulatorArm64Test`, `compileKotlinLinuxArm64`, `compileKotlinMingwX64`
- `jvmTest` still passes with the new configuration

**Not run locally, and worth knowing before merging:** every native compilation and test (Konan host blocked), and every JS/Wasm test. The latter is not about `browser()` — `kotlinNpmInstall` itself fails here because yarn can't fetch `github.com/Kotlin/karma` through the sandbox proxy, which blocks node and browser runs alike. So `jsBrowserTest`, `wasmJsTest`, and all native tests get their first real execution in CI on this PR. If any of them fail I'll drive them to green rather than leave it to you.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fU2nRFSCBaAHnp7Ms5TLb)_