### PR TITLE
Docs overhaul: README, MIGRATION.md, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Version History
 
+## 0.4.0 (unreleased)
+
+**Breaking changes.** The API was reshaped while there are no external consumers.
+
+* `Iban.parse`, `Iban.compose` and `Iban(...)` now return `Result<Iban>` instead of throwing. Failures carry a
+  sealed `IbanParseException` — `Malformed` (with a `kind`), `UnknownCountryCode`, `WrongLength`,
+  `WrongChecksum` — which extends `IllegalArgumentException`, so `getOrThrow()` matches the old behaviour.
+* `String.toIban()` returns `Result<Iban>`; added `String.toIbanOrNull()`.
+* Removed `IBANFields`; use `Iban.bankIdentifier` and `Iban.branchIdentifier`.
+* `CountryCodes.lastUpdateDate` is a `kotlin.time.Instant` from the standard library, and the kotlinx-datetime
+  dependency is gone. The library now has no dependencies beyond the Kotlin standard library.
+
+**Fixes**
+
+* `Iban.compose` produced an invalid IBAN for every country whose check digits are 10 or higher: the computed
+  digits were discarded and `00` was left in place, so the result failed its own checksum validation.
+
+**Data**
+
+* SWIFT IBAN Registry updated from rev 97 (2024-05-25) to rev 102. Yemen added; Honduras promoted into the
+  registry; Poland's 8-digit routing code reclassified from branch to bank identifier; Jordan gained a branch
+  identifier; AL, MD, ME, MK and RS flagged as SEPA.
+* Added `scripts/generate_country_data.main.kts`, which regenerates the country data and its test table from the
+  registry TXT with cross-validation against the registry's own identifier examples.
+
+**Targets**
+
+* Added `wasmJs`, `macosX64`, `macosArm64`, `tvosX64`, `tvosArm64`, `tvosSimulatorArm64`, `watchosX64`,
+  `watchosArm64`, `watchosDeviceArm64`, `watchosSimulatorArm64`, `linuxArm64` and `mingwX64`, and the browser
+  environment for `js`.
+
+**Documentation**
+
+* Added installation instructions, `MIGRATION.md`, and a changelog entry for 0.3.0.
+
+## 0.3.0
+
+First release published to Maven Central, as `nl.bijdorpstudio.kiban:kiban`.
+
+* Kotlin-idiomatic API alongside the java-iban one: `plain` and `pretty` properties, `bankIdentifier` and
+  `branchIdentifier` on `Iban`, `Iban(...)` as an operator, and the `String.toIban()` / `String.isValidIban()`
+  extensions.
+* `CountryCodes.getLength` returns `Int?` instead of `-1` for unknown country codes; `lastUpdateDate` became a
+  date type rather than a string; `IBAN.toPretty` became `Iban.format`.
+* The java-iban API is kept as a deprecated compat layer with `ReplaceWith` migrations: the `IBAN` typealias,
+  `valueOf`, `toPlainString`, `toPretty`, `getLengthForCountryCode` and `lastUpdateDateString`.
+* Binary compatibility validation (`apiCheck`) added for the JVM and klib targets.
+
 ## 0.2.0
 * Parity of API with java library complete (except from the ancient Java version)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,125 @@
+# Migration guide
+
+Kiban is a port of [`java-iban`](https://github.com/barend/java-iban). This document maps the old API onto the
+current one, both for people arriving from `java-iban` and for people upgrading from kiban 0.3.0 or earlier.
+
+Most of the work is mechanical. The deprecated declarations carry `ReplaceWith`, so the IDE can apply the
+majority of these changes for you: **Code > Inspect Code**, or Alt+Enter on each warning. The compat layer stays
+in place until 1.0.
+
+## Package and type names
+
+| java-iban | kiban |
+| --- | --- |
+| `nl.garvelink.iban` | `nl.bijdorpstudio.kiban` |
+| `IBAN` | `Iban` (a deprecated `typealias IBAN = Iban` exists on JVM) |
+| `Modulo97` | `Modulo97` |
+| `CountryCodes` | `CountryCodes` |
+| `IBANFields` | removed — use `Iban.bankIdentifier` / `Iban.branchIdentifier` |
+| `IBANFieldsCompat` | never ported |
+
+## Parsing
+
+The big change. `Iban.parse` returns `Result<Iban>` instead of throwing.
+
+| Before | Now |
+| --- | --- |
+| `IBAN.valueOf(input)` | `Iban.parse(input).getOrThrow()` — or better, handle the `Result` |
+| `IBAN.parse(input)` | `Iban.parse(input)`, which now returns `Result<Iban>` |
+| `try { IBAN.valueOf(s) } catch (e: IllegalArgumentException) { null }` | `s.toIbanOrNull()` |
+| `try { IBAN.valueOf(s); true } catch (e: IllegalArgumentException) { false }` | `s.isValidIban()` |
+
+`getOrThrow()` throws the same `IllegalArgumentException` the old API threw, so the narrowest possible migration
+is to append it to every call and change nothing else:
+
+``` kotlin
+// java-iban
+val iban = IBAN.valueOf(input)
+
+// kiban, minimal change
+val iban = Iban.parse(input).getOrThrow()
+
+// kiban, idiomatic
+Iban.parse(input).fold(
+    onSuccess = { accept(it) },
+    onFailure = { showError(it.message) }
+)
+```
+
+### Typed failures
+
+Catching `IllegalArgumentException` and reading `message` is no longer necessary. Failures carry a sealed type:
+
+``` kotlin
+when (val failure = Iban.parse(input).exceptionOrNull()) {
+    is IbanParseException.UnknownCountryCode -> failure.countryCode
+    is IbanParseException.WrongLength -> "${failure.actualLength} != ${failure.expectedLength}"
+    is IbanParseException.WrongChecksum -> "check digits do not match"
+    is IbanParseException.Malformed -> failure.kind.name
+    null -> "parsed successfully"
+}
+```
+
+`IbanParseException` extends `IllegalArgumentException`, so existing `catch` blocks around `getOrThrow()` keep
+working unchanged.
+
+## Instance API
+
+| Before | Now |
+| --- | --- |
+| `iban.toPlainString()` | `iban.plain` |
+| `iban.toString()` | `iban.toString()` or `iban.pretty` (unchanged behaviour: spaced formatting) |
+| `IBAN.toPretty(input)` | `Iban.format(input)` |
+| `IBAN.toPlain(input)` | `Iban.toPlain(input)` |
+| `iban.countryCode` | `iban.countryCode` |
+| `iban.checkDigits` | `iban.checkDigits` |
+| `iban.isSEPA` / `iban.isInSwiftRegistry` | unchanged |
+
+## Bank and branch identifiers
+
+| Before | Now |
+| --- | --- |
+| `IBANFields.getBankIdentifier(iban)` → `Optional<String>` | `iban.bankIdentifier` → `String?` |
+| `IBANFields.getBranchIdentifier(iban)` → `Optional<String>` | `iban.branchIdentifier` → `String?` |
+| `CountryCodes.getBankIdentifier(iban)` | `iban.bankIdentifier` |
+| `CountryCodes.getBranchIdentifier(iban)` | `iban.branchIdentifier` |
+
+`IBANFields` was JVM-only and returned `java.util.Optional`; it is gone. Kotlin's nullable types cover the same
+ground, and `?:` replaces `orElse`.
+
+## CountryCodes
+
+| Before | Now |
+| --- | --- |
+| `CountryCodes.getLengthForCountryCode(cc)` → `-1` when unknown | `CountryCodes.getLength(cc)` → `Int?`, `null` when unknown |
+| `CountryCodes.LAST_UPDATE_DATE` / `lastUpdateDateString` | `CountryCodes.lastUpdateDate` → `kotlin.time.Instant` |
+| `CountryCodes.LAST_UPDATE_REV` | `CountryCodes.lastUpdateRevision` |
+| `CountryCodes.isKnownCountryCode(cc)` | unchanged |
+| `CountryCodes.isSEPACountry(cc)` | unchanged |
+
+## Composition
+
+`Iban.compose` also returns a `Result`:
+
+``` kotlin
+// before
+val iban = IBAN.compose("BI", "10000100010000332045181")
+
+// now
+val iban = Iban.compose("BI", "10000100010000332045181").getOrThrow()
+```
+
+If you used `compose` on kiban 0.3.0, note that it was broken for any country whose check digits are 10 or
+higher — it produced an IBAN with `00` check digits and then rejected it. Upgrading fixes that; there is no
+workaround to remove from your code, since the call simply failed before.
+
+## Modulo97
+
+Unchanged, and still throwing. `Modulo97.checksum`, `calculateCheckDigits`, and `verifyCheckDigits` all take
+`CharSequence` and raise `IllegalArgumentException` on malformed input, because their inputs come from the
+programmer rather than from an end user.
+
+## Things that were never ported
+
+* `IBANFieldsCompat` — the Java 6/7 compatibility shim for `IBANFields`.
+* Any API that took a `java.util.Locale` or returned a `java.util.Optional`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![Kiban](.idea/icon.svg)
 # **K**Iban—Kotlin Multiplatform IBAN Library
 
+[![Maven Central](https://img.shields.io/maven-central/v/nl.bijdorpstudio.kiban/kiban.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/nl.bijdorpstudio.kiban/kiban)
+[![CI](https://github.com/BijdorpStudio/kiban/actions/workflows/gradle.yml/badge.svg)](https://github.com/BijdorpStudio/kiban/actions/workflows/gradle.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 ## Introduction
 
@@ -16,43 +19,88 @@ The original [`java-iban`]((https://github.com/barend/java-iban)) library laid a
 
 - Validate International Bank Account Numbers (IBANs).
 - Retrieve country-specific IBAN details.
+- No dependencies beyond the Kotlin standard library.
 - Multiplatform compatibility across Kotlin-supported targets.
+
+## Installation
+
+Artifacts are published to Maven Central.
+
+``` kotlin
+dependencies {
+    implementation("nl.bijdorpstudio.kiban:kiban:0.3.0")
+}
+```
+
+In a multiplatform project, add it to `commonMain`:
+
+``` kotlin
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("nl.bijdorpstudio.kiban:kiban:0.3.0")
+        }
+    }
+}
+```
+
+Supported targets: JVM, Android, `js` (Node.js and browser), `wasmJs` (Node.js and browser), iOS, macOS, watchOS, tvOS, `linuxX64`, `linuxArm64`, and `mingwX64`.
 
 ## Use
 
-Obtain an `Iban` instance using one of the static factory methods: `valueOf( )` and `parse( )`. Methods throw `IllegalArgumentException` on invalid input.
+Parsing returns a `kotlin.Result`, so invalid input is a value rather than an exception. Nothing in the library throws for bad user input.
 
 ``` kotlin
-    // Obtain an instance of Iban.
-    val iban = Iban.valueOf( "NL91ABNA0417164300" )
+    // Parse returns Result<Iban>.
+    val iban: Iban = Iban.parse( "NL91ABNA0417164300" ).getOrThrow()
 
-    // toString() emits standard formatting, toPlainString() is compact.
+    // Handle failure without exceptions.
+    Iban.parse( input ).fold(
+        onSuccess = { accept( it ) },
+        onFailure = { showError( it.message ) }
+    )
+
+    // Or use the String extensions.
+    val parsed: Result<Iban> = "NL91ABNA0417164300".toIban()
+    val orNull: Iban? = "NL91ABNA0417164301".toIbanOrNull() // null, check digits are wrong
+    val isValid: Boolean = "NL91ABNA0417164300".isValidIban() // true
+
+    // Failures carry a typed reason, so you never have to match on messages.
+    when ( val failure = Iban.parse( input ).exceptionOrNull() ) {
+        is IbanParseException.UnknownCountryCode -> reportUnknown( failure.countryCode )
+        is IbanParseException.WrongLength -> reportLength( failure.expectedLength, failure.actualLength )
+        is IbanParseException.WrongChecksum -> reportChecksum()
+        is IbanParseException.Malformed -> reportMalformed( failure.kind )
+        null -> Unit // parsed successfully
+    }
+
+    // toString() emits standard formatting, plain is compact.
     val formatted = iban.toString() // "NL91 ABNA 0417 1643 00"
-    val plain = iban.toPlainString() // "NL91ABNA0417164300"
+    val plain = iban.plain // "NL91ABNA0417164300"
 
     // Input may be formatted.
-    val anotherIban = Iban.valueOf( "BE68 5390 0754 7034" )
-    
-    // IBAN implements Comparable<T>.
+    val anotherIban = Iban.parse( "BE68 5390 0754 7034" ).getOrThrow()
+
+    // Iban implements Comparable<T>.
     val ibans = getListOfIBANs()
     ibans.sorted() // sorts in lexical order
-    
+
     // The equals() and hashCode() methods are implemented.
     val ibansAsKeys = mutableMapOf<Iban, String>()
     ibansAsKeys.put( iban, "this is fine" )
-    
+
     // You can use the Modulo97 class directly to compute or verify the check digits on an input.
     val candidate = "GB29 NWBK 6016 1331 9268 19"
     val valid = Modulo97.verifyCheckDigits( candidate ) // true
-    
-    // Compose the IBAN for a country and BBAN
-    Iban.compose( "BI", "201011067444" ) // BI43201011067444
+
+    // Compose the IBAN for a country and BBAN; this also returns a Result.
+    Iban.compose( "BI", "10000100010000332045181" ).getOrThrow() // BI4210000100010000332045181
 
     // You can query whether an IBAN is of a SEPA-participating country
-    val isSepa = Iban.parse(candidate).isSEPA // true
+    val isSepa = Iban.parse( candidate ).getOrThrow().isSEPA // true
 
     // You can query whether an IBAN is in the SWIFT Registry
-    val isRegistered = Iban.parse(candidate).isInSwiftRegistry // true
+    val isRegistered = Iban.parse( candidate ).getOrThrow().isInSwiftRegistry // true
 
     // Modulo97 API methods take CharSequence, not just String.
     val builder = StringBuilder( "LU000019400644750000" )
@@ -61,19 +109,19 @@ Obtain an `Iban` instance using one of the static factory methods: `valueOf( )` 
     // Modulo97 API can calculate check digits, also for non-iban inputs.
     // It does assume/require that the check digits are on indices 2 and 3.
     Modulo97.calculateCheckDigits( "GB", "NWBK60161331926819" ) // 29
-    Modulo97.calculateCheckDigits( "XX", "X" ) // 50
+    Modulo97.calculateCheckDigits( "XX", "X" ) // 72
 
     // Get the expected IBAN length for a country code:
-    val expectedLength = CountryCodes.getLengthForCountryCode( "DK" )
+    val expectedLength: Int? = CountryCodes.getLength( "DK" ) // 18
 
     // Get the Bank Identifier and Branch Identifier:
-    val bankId: String? = CountryCodes.getBankIdentifier( iban )
-    val branchId: String? = CountryCodes.getBranchIdentifier( iban )
-
-    // Get the Bank Identifier and Branch Identifier as Java Optional:
-    val bankId = IbanFields.getBankIdentifier( iban ) // Optional<String>
-    val branchId = IbanFields.getBranchIdentifier( iban ) // Optional<String>
+    val bankId: String? = iban.bankIdentifier
+    val branchId: String? = iban.branchIdentifier
 ```
+
+`Modulo97` is the one part of the library that still throws: its inputs are programmer-supplied, so a bad one is a contract violation rather than user input to be validated.
+
+Migrating from `java-iban` or from kiban 0.3.0 and earlier? See [MIGRATION.md](MIGRATION.md).
 
 ## Design choices
 
@@ -85,16 +133,19 @@ I [(Barend)](https://github.com/barend) like the Joda-Time library, and I try to
   * It checks that the length is correct (varies per country) and that the check digits are correct.
   * The national format mask (such as `QA2!n4!a21!c`) is not enforced. This seems to me like more work than necessary. The modulo-97 checksum catches most input errors anyway, and I don't want to force a memory-hungry regex check onto Android users. Speaking of Android, this mask could be used for keyboard switching on an Iban EditText, but that's for a different open-source project.
   * Any national check digits are not enforced. Doing this right is more work than I want to put into this. I lack the country-specific knowledge of all the gotchas and intricacies. If other countries' check digits are anything like those in the Netherlands, they're going to differ by Bank Identifier.
-* There is no way to configure extra restrictions such as "only SEPA countries" on the `Iban.valueOf()` method. This, to me, would look too much like Joda-Time's pluggable `Chronology` system, which leads to PoLS violations (background: [Why JSR-310 isn't Joda-Time](https://blog.joda.org/2009/11/why-jsr-310-isn-joda-time_4941.html)).
+* There is no way to configure extra restrictions such as "only SEPA countries" on the `Iban.parse()` method. This, to me, would look too much like Joda-Time's pluggable `Chronology` system, which leads to PoLS violations (background: [Why JSR-310 isn't Joda-Time](https://blog.joda.org/2009/11/why-jsr-310-isn-joda-time_4941.html)).
 * There is no class to represent a partially entered IBAN or a potentially-invalid IBAN. I'm sure there are use cases where you want to shift this sort of data around. As far as this library is concerned, if it's not an Iban it's just a string, and there already exist data types for dealing with those.
 * Any feature that's not present in all IBAN's is kept outside the `Iban` class. Currently, that's the support for extracting Bank and Branch identifiers, which lives in the `CountryCode` class.
 * The library originally supported an SDK 14 (Ice Cream Sandwich) era Android app. This is why it relies on bit-packing to reduce bytecode size.
 
 ### Kotlin library
 
-Adopted design choices from Java library and going to do next:
-* Kotlinize API so it is idiomatic to Kotlin user
-* Deprecate old API and provide automatic migrate mechanism
+Adopted design choices from the Java library, plus:
+* Kotlinize the API so it is idiomatic for Kotlin users.
+* Parsing reports failure as `Result.failure` carrying a sealed `IbanParseException`, rather than by throwing. The exception type extends `IllegalArgumentException`, so `getOrThrow()` behaves exactly like the old throwing API, and callers who want typed errors can inspect the failure instead of matching on messages.
+* `Modulo97` keeps throwing: it is a low-level utility whose errors indicate a contract violation, not invalid user input.
+* Deprecate old API and provide an automatic migration mechanism through `ReplaceWith`. The compat layer is kept until 1.0.
+* Zero dependencies: only the Kotlin standard library, which is what lets the library ship on every Kotlin target.
 
 ## References
 


### PR DESCRIPTION
Closes #51.

Docs only — no source or build changes.

## README

- **Badges**: Maven Central, CI, licence.
- **Installation**: the `nl.bijdorpstudio.kiban:kiban` coordinates, both plain and `commonMain` forms, plus the supported target list from #50.
- **Examples rewritten for the Result API**: `parse(...).getOrThrow()`, `fold`, `toIban` / `toIbanOrNull` / `isValidIban`, and a `when` over the sealed `IbanParseException` showing that callers get typed reasons instead of message matching. The `IBANFields` example is gone (removed in #47) and the `CountryCodes.getBankIdentifier` calls are now the `Iban` properties.
- **Design choices**: the Kotlin section described only "kotlinize the API"; it now records the Result decision, why `Modulo97` still throws, and the zero-dependency property from #48. One stray `Iban.valueOf()` reference in the java-iban section is now `Iban.parse()`.

The issue also asked me to remove a stale Bignum-dependency note — there isn't one left. It appears to have been cleaned up in #55, and the surrounding line already states the library depends only on the Kotlin standard library.

## MIGRATION.md

New. Mapping tables for package/type renames, parsing, the instance API, bank/branch identifiers, `CountryCodes`, composition, and `Modulo97`, plus a short section on what was never ported (`IBANFieldsCompat`, the `Optional`/`Locale` APIs). It leads with the minimal migration — append `.getOrThrow()` and change nothing else — before showing the idiomatic form, since that is what makes the upgrade cheap to start.

It also notes that `compose` on 0.3.0 was broken for check digits >= 10, so upgraders know there is nothing to un-work-around.

## CHANGELOG

Retroactive 0.3.0 entry (it was missing even though 0.3.0 is on Maven Central) reconstructed from the merged PRs, and a `0.4.0 (unreleased)` entry covering the Result API, the compose fix, the registry update to rev 102, the zero-dependency change, the new targets, and the removal of `IBANFields`.

## One correction found while writing this

I verified every value the README quotes by asserting it against the current code in a temporary test, then deleted the test. All but one matched. The old README claimed:

```kotlin
Modulo97.calculateCheckDigits( "XX", "X" ) // 50
```

The correct answer is **72**, and the library returns 72. Check: `XX72X` rearranges to `33333372`, which is `97 × 343643 + 1`, so it verifies; `XX50X` gives `33333350`, a remainder of 76, which does not. The 50 appears to have been wrong since it was written rather than a regression — I found no code change that could have altered it. README now says 72.

## Two things left deliberately

- **The version in the install snippet is `0.3.0`**, the currently published release. It will need bumping when 0.4.0 ships, along with `version` in `library/build.gradle.kts`, which still reads `0.3.0`.
- **`IBANFields` is described as removed**, which is true once #59 (issue #47) merges. That PR is open and independent of this one; if you merge this first, the MIGRATION and CHANGELOG entries run slightly ahead of the code for as long as #59 is unmerged.

## Verification

No code changed, so there is nothing for the test suite to catch here beyond confirming the snippets — which I did as described above, against the real API on this commit's parent.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fU2nRFSCBaAHnp7Ms5TLb)_