### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version History
 
-## 0.4.0 (unreleased)
+## 0.4.0
 
 **Breaking changes.** The API was reshaped while there are no external consumers.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Artifacts are published to Maven Central.
 
 ``` kotlin
 dependencies {
-    implementation("nl.bijdorpstudio.kiban:kiban:0.3.0")
+    implementation("nl.bijdorpstudio.kiban:kiban:0.4.0")
 }
 ```
 
@@ -38,7 +38,7 @@ In a multiplatform project, add it to `commonMain`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("nl.bijdorpstudio.kiban:kiban:0.3.0")
+            implementation("nl.bijdorpstudio.kiban:kiban:0.4.0")
         }
     }
 }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "nl.bijdorpstudio.kiban"
-version = "0.3.0"
+version = "0.4.0"
 
 tapmoc {
     java(libs.versions.java.version.get().toInt())


### PR DESCRIPTION
Release prep for 0.4.0, now that every issue in the milestone is closed.

| File | Change |
| --- | --- |
| `library/build.gradle.kts` | `version = "0.3.0"` → `"0.4.0"` — this is the one that gets published |
| `README.md` | both install snippets, plain and `commonMain` |
| `CHANGELOG.md` | dropped `(unreleased)` from the `## 0.4.0` heading |

I checked the remaining `0.3.0` occurrences and left them alone deliberately: the MIGRATION.md and README references to "0.3.0 and earlier" are historical and still correct, the CHANGELOG's own `## 0.3.0` section is history, and `tapmoc-plugin = "0.3.0"` in the version catalog is an unrelated coincidence.

## Verification

Nothing to run locally beyond what CI does — no code changed, and no test or API dump references the version. The matrix on this PR is the check.

## Before cutting the release

Two things I flagged separately, repeated here so they're next to the button:

1. **`publish.yml` has never executed its new shape.** #57 added the `test` job and `secrets: inherit`, but that workflow only triggers on a release event, so 0.4.0 will be its first real run. A failure there is safe — it aborts before publishing — but it does abort the release. Cutting a **prerelease** first exercises the whole path, since `prereleased` is in the trigger list.
2. **`kotlin.native.ignoreDisabledTargets=true`** (`gradle.properties:14`) makes Gradle skip host-unbuildable targets silently rather than failing. This is the first release with 17 klib targets instead of 5. Publishing runs on `macOS-latest`, which should support all of them, but the flag means a partial publish would look like a successful one — worth checking the artifact list on Maven Central afterwards, or dropping the flag so a missing target fails loudly.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fU2nRFSCBaAHnp7Ms5TLb)_