### PR TITLE
Open the 0.5.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Version History
 
+## 0.5.0 (unreleased)
+
 ## 0.4.0
 
 **Breaking changes.** The API was reshaped while there are no external consumers.

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "nl.bijdorpstudio.kiban"
-version = "0.4.0"
+version = "0.5.0"
 
 tapmoc {
     java(libs.versions.java.version.get().toInt())


### PR DESCRIPTION
Moves `main` onto the next version now that 0.4.0 is released.

| File | Change |
| --- | --- |
| `library/build.gradle.kts` | `version = "0.4.0"` → `"0.5.0"` |
| `CHANGELOG.md` | empty `## 0.5.0 (unreleased)` section to collect entries |

**The README install snippets stay at `0.4.0` on purpose.** They tell a reader what to depend on, which is the latest *released* version, not what `main` is building towards. This is a change from the previous convention, where the project version tracked the last release until release prep — worth knowing because it makes the two numbers legitimately different from now on.

That also settles the README version guard we discussed and deferred: it would have to compare the snippet against the latest release, not against `project.version`, or it would fail on every commit of this cycle.

Milestone [0.5.0](https://github.com/BijdorpStudio/kiban/milestone/6) created alongside this.

## Not included: dependency updates

You asked about bumping versions generally, so for the record — the catalog has real updates available, and I left them out of this PR deliberately:

| Entry | Current | Latest stable |
| --- | --- | --- |
| `kotlin` | 2.3.10 | 2.4.10 |
| `kotlinx-binary-compatibility-validator` | 0.17.0 | 0.18.1 |
| `assertk` | 0.28.1 | already current |
| `agp` | 9.0.0 | couldn't check — `dl.google.com` is blocked in my sandbox |

A Kotlin minor bump can change klib ABI rendering and interacts with `kotlin-version = "2.3.0"` (the tapmoc compatibility setting), and I can't compile native or Android locally to see the fallout, so CI would be the first real signal. Worth its own PR at the start of the cycle rather than riding along with a version bump. I also avoided running `versionCatalogUpdate`: getting Gradle to configure here means disabling the Android plugin, and the plugin prunes entries it considers unused, so it could quietly drop `agp`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019fU2nRFSCBaAHnp7Ms5TLb)_