### PR TITLE
Add Dependabot for Gradle dependencies and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+# Dependency updates for the two ecosystems this repository actually uses:
+# the Gradle version catalog and the actions the workflows depend on.
+#
+# This does not replace the `nl.littlerobots.version-catalog-update` plugin
+# configured in the root build script. The two solve the same problem from
+# opposite directions and both are wanted: Dependabot keeps the catalog from
+# drifting between releases, one PR at a time, while `./gradlew
+# versionCatalogUpdate` stays the bulk sweep run deliberately at the start of
+# a development cycle.
+version: 2
+
+updates:
+  # Dependabot reads `gradle/libs.versions.toml` directly, so every catalog
+  # entry that resolves to a real module is covered without extra
+  # configuration. The `# @keep` versions (`android-compileSdk`,
+  # `android-minSdk`, `java-version`, `kotlin-version`) are not dependency
+  # declarations and are left alone.
+  #
+  # Two things to know about the PRs this produces:
+  #
+  #   * A Kotlin bump can change klib ABI rendering, so such a PR may fail
+  #     `apiCheck` until someone runs `./gradlew apiDump` on the branch.
+  #     Dependabot cannot finish those on its own.
+  #   * AGP (`com.android.kotlin.multiplatform.library`) is published only to
+  #     Google's Maven repository — it is not on Maven Central, and the
+  #     Gradle Plugin Portal just redirects there. So AGP coverage depends
+  #     entirely on Dependabot honouring the `google()` declarations in
+  #     `settings.gradle.kts`. That is expected to work but has not been
+  #     observed on this repository yet. If AGP is still sitting at an old
+  #     version after a few runs while other entries move, this comment
+  #     should be replaced by an explicit note that AGP stays manual, rather
+  #     than leaving a false sense of coverage.
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Every PR runs the full check matrix — eleven jobs, four of them on
+    # macOS runners. Batching patch and minor bumps into a single PR keeps
+    # the noise down; major bumps still arrive one per PR, where they get the
+    # individual review they need.
+    groups:
+      gradle-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering the two ecosystems in play: the Gradle version catalog and the actions used by the workflows. Dependabot reads `gradle/libs.versions.toml` directly, so catalog entries are covered without extra configuration.

## Decisions taken

The issue listed four things to settle while implementing. Each is settled in the config, with the reasoning kept in comments next to the setting it explains rather than in a separate document.

**Grouping.** Patch and minor updates are batched into one PR per ecosystem per week (`groups:` with `patterns: ["*"]` and `update-types: [minor, patch]`); majors keep arriving one per PR. Every PR triggers the full eleven-job matrix, four of those on macOS runners, so ungrouped weekly updates would be a lot of noise for routine bumps — while a major is exactly the case that wants its own PR and its own review.

**Overlap with `versionCatalogUpdate`.** The plugin stays. The two are complementary rather than redundant: Dependabot keeps the catalog from drifting between releases, and `./gradlew versionCatalogUpdate` remains the deliberate bulk sweep at the start of a development cycle. This is written into the file header so the next person doesn't read one of them as dead weight.

**Kotlin bumps needing a follow-up.** Recorded as a comment on the Gradle entry: a Kotlin bump can change klib ABI rendering, so such a PR may sit red on `apiCheck` until someone runs `./gradlew apiDump` on the branch. Dependabot cannot finish those on its own.

**AGP from Google's Maven repo.** Verified from this workspace that `com.android.kotlin.multiplatform.library` 9.0.0 is published *only* to Google's Maven repository — Maven Central returns 404 for the plugin marker, and the Gradle Plugin Portal answers with a redirect to Maven Central, which also 404s. So AGP coverage rests entirely on Dependabot honouring the `google()` declarations in `settings.gradle.kts`. That is the expected behaviour but it has not been observed on this repository yet, so the comment says exactly that, plus what to do if it turns out false: replace the comment with an explicit "AGP stays manual" note rather than leave a false sense of coverage. It seemed better to record the open question honestly than to claim coverage that only the first live run can confirm.

Auto-merge for green Dependabot PRs is left out, as the issue scoped it.

## Verification

The config parses as valid YAML and matches the documented `version: 2` schema (two `updates` entries, one group per ecosystem).

`./gradlew jvmTest` and `./gradlew apiCheck` could **not** be run in this workspace: its network policy blocks `dl.google.com`, so Gradle cannot resolve the AGP plugin marker and the build fails during configuration, before any task runs. That is an environment limitation, not something this branch introduces — no Gradle, Kotlin, or public-API file is touched here, so neither task's outcome can change. CI on this PR runs the full matrix, including both tasks, and is the real check.

Closes #63

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4K2Rh3UvXDKCtJqm8GJYE)_