### PR TITLE
Enable Android host tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -40,7 +40,7 @@ jobs:
           # doubles as the compile check for the Apple targets.
           - target: apiCheck
             os: macos-latest
-          - target: assembleAndroidMain androidCompileLintChecks
+          - target: assembleAndroidMain androidCompileLintChecks :library:testAndroidHostTest
             os: ubuntu-latest
           # Generation only, no deploy: catches broken KDoc/sourceLink before a
           # release tag is cut. Actual publish to GitHub Pages stays in publish.yml.

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         namespace = "nl.bijdorpstudio.kiban"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
+        withHostTest {}
     }
     iosX64()
     iosArm64()


### PR DESCRIPTION
The AGP KMP plugin (`com.android.kotlin.multiplatform.library`) makes test
compilations opt-in, so `commonTest` was never run against the Android target.
The plugin warns about this at configuration time:

```
WARNING: The 'commonTest' source directory exists, but android host tests are not
enabled. To enable android host tests, add `withHostTest {}` to your android
target configuration in the Gradle build file.
```

- `withHostTest {}` on the `android` target, which creates the `androidHostTest`
  compilation and the `testAndroidHostTest` task.
- Appended `:library:testAndroidHostTest` to the existing Android CI entry rather
  than adding a matrix entry — that ubuntu runner already has the SDK and the job
  already exists.

### Verification

`./gradlew :library:testAndroidHostTest` run locally on macOS: **BUILD SUCCESSFUL,
76 tests, 0 failures, 1 skipped** — exact parity with `jvmTest` (same 76, same
single `@Ignore`d case in `CountryCodesTest`). Local run needed `ANDROID_HOME` set
explicitly; nothing was written to `local.properties`.

The Android job now compiles and runs tests where it previously only assembled, so
expect it to take longer. This is also the first time these tests run on a Linux
runner rather than locally on macOS.

Coverage here is largely redundant with `jvmTest` today — `commonMain` is pure
Kotlin with no `java.*` usage — but host tests link against `android.jar` stubs and
resolve Android dependency variants, so they'd catch minSdk/desugaring issues the
JVM run cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)