### PR TITLE
0.5.0 API cleanup: strict throwing parsing, remove Result and all deprecated members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 0.5.0 (unreleased)
 
+**Breaking changes**
+
+* Reverted parsing from `Result`-returning (introduced in 0.4.0) back to strict and throwing. `Iban(input)`,
+  `Iban.compose(cc, bban)` and `String.toIban()` now return `Iban` directly and throw a sealed
+  `IbanParseException` on invalid input, instead of returning `Result<Iban>`. 0.4.0's `Result` shape did not
+  survive the trip to Swift (#9); this corrects it before a second published version carries it forward. The
+  throwing entry points are annotated `@Throws(IbanParseException::class)`, which Kotlin/Native's Objective-C
+  exporter needs to surface a catchable Swift error instead of aborting the process.
+* Removed `Iban.parse` and `Iban.valueOf` — use `Iban(input)` or `String.toIban()`.
+* Removed `Iban.format` and `Iban.toPretty` — parse and use `iban.pretty` instead.
+* Removed every other `@Deprecated` member: `Iban.toPlainString()`, `CountryCodes.getBankIdentifier(Iban)`,
+  `CountryCodes.getBranchIdentifier(Iban)`, `CountryCodes.getLengthForCountryCode(cc)`, and
+  `CountryCodes.lastUpdateDateString`. See [MIGRATION.md](MIGRATION.md) for the full mapping.
+
 **Targets**
 
 * Removed `macosX64`, `tvosX64` and `watchosX64`, which JetBrains deprecated in Kotlin 2.3.20.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,18 +1,48 @@
 # Migration guide
 
 Kiban is a port of [`java-iban`](https://github.com/barend/java-iban). This document maps the old API onto the
-current one, both for people arriving from `java-iban` and for people upgrading from kiban 0.3.0 or earlier.
+current one, for people arriving from `java-iban`, from kiban 0.3.0 or earlier, or from the `Result`-returning
+kiban 0.4.0 API.
 
-Most of the work is mechanical. The deprecated declarations carry `ReplaceWith`, so the IDE can apply the
-majority of these changes for you: **Code > Inspect Code**, or Alt+Enter on each warning. The compat layer stays
-in place until 1.0.
+The library has not reached 1.0 yet, so there is no deprecation cycle or compat layer: removed API is gone, not
+deprecated. Every break below is a compile error, not a runtime surprise.
+
+## Upgrading from kiban 0.4.0 to 0.5.0
+
+0.4.0 made `Iban.parse`, `Iban(...)`, `String.toIban()` and `Iban.compose` return `Result<Iban>` instead of
+throwing. That shape didn't survive the trip to Swift (see
+[`docs/9-swift-interop-review.md`](docs/9-swift-interop-review.md)), so 0.5.0 reverts it: parsing is strict again
+and throws a typed `IbanParseException`. 0.5.0 also removes every member that was `@Deprecated` in 0.4.0 and
+earlier — there are no replacements to reach for beyond what's listed here.
+
+| From | To |
+| --- | --- |
+| `Iban.parse(s)` | `Iban(s)` |
+| `Iban.parse(s).getOrThrow()` | `Iban(s)` |
+| `Iban.parse(s).getOrNull()` | `s.toIbanOrNull()` |
+| `Iban.parse(s).exceptionOrNull()` | `try { Iban(s) } catch (e: IbanParseException) { … }` |
+| `Iban.parse(s).fold(...)` | `try`/`catch`, or `runCatching { Iban(s) }.fold(...)` |
+| `Iban(s)` *(returned `Result`)* | `Iban(s)` — now returns `Iban` directly, throws |
+| `"...".toIban()` *(returned `Result`)* | `"...".toIban()` — now returns `Iban` directly, throws |
+| `Iban.valueOf(s)` | `Iban(s)` |
+| `Iban.compose(cc, bban).getOrThrow()` | `Iban.compose(cc, bban)` |
+| `Iban.format(s)` | no replacement — parse, then use `iban.pretty` |
+| `Iban.toPretty(s)` / `Iban.toPlain(s)` | no replacement — parse, then `iban.pretty` / `iban.plain` |
+| `iban.toPlainString()` | `iban.plain` |
+| `CountryCodes.getBankIdentifier(iban)` | `iban.bankIdentifier` |
+| `CountryCodes.getBranchIdentifier(iban)` | `iban.branchIdentifier` |
+| `CountryCodes.getLengthForCountryCode(cc)` | `CountryCodes.getLength(cc) ?: -1` |
+| `CountryCodes.lastUpdateDateString` | `CountryCodes.lastUpdateDate` |
+
+`runCatching { Iban(s) }` reproduces the old `Result`-returning behaviour exactly, for anyone who wants it back
+locally without touching the public API.
 
 ## Package and type names
 
 | java-iban | kiban |
 | --- | --- |
 | `nl.garvelink.iban` | `nl.bijdorpstudio.kiban` |
-| `IBAN` | `Iban` (a deprecated `typealias IBAN = Iban` exists on JVM) |
+| `IBAN` | `Iban` (a `typealias IBAN = Iban` exists on JVM) |
 | `Modulo97` | `Modulo97` |
 | `CountryCodes` | `CountryCodes` |
 | `IBANFields` | removed — use `Iban.bankIdentifier` / `Iban.branchIdentifier` |
@@ -20,48 +50,43 @@ in place until 1.0.
 
 ## Parsing
 
-The big change. `Iban.parse` returns `Result<Iban>` instead of throwing.
+`Iban(input)` — or the `invoke` operator's spelling, `Iban.invoke(input)` — is the primary entry point. It
+validates the input and confirms the check digits, throwing `IbanParseException` on any failure.
 
 | Before | Now |
 | --- | --- |
-| `IBAN.valueOf(input)` | `Iban.parse(input).getOrThrow()` — or better, handle the `Result` |
-| `IBAN.parse(input)` | `Iban.parse(input)`, which now returns `Result<Iban>` |
+| `IBAN.valueOf(input)` | `Iban(input)` |
+| `IBAN.parse(input)` | `Iban(input)` |
 | `try { IBAN.valueOf(s) } catch (e: IllegalArgumentException) { null }` | `s.toIbanOrNull()` |
 | `try { IBAN.valueOf(s); true } catch (e: IllegalArgumentException) { false }` | `s.isValidIban()` |
 
-`getOrThrow()` throws the same `IllegalArgumentException` the old API threw, so the narrowest possible migration
-is to append it to every call and change nothing else:
+`IbanParseException` extends `IllegalArgumentException`, so the narrowest possible migration from java-iban is to
+change nothing but the call itself:
 
 ``` kotlin
 // java-iban
 val iban = IBAN.valueOf(input)
 
-// kiban, minimal change
-val iban = Iban.parse(input).getOrThrow()
-
-// kiban, idiomatic
-Iban.parse(input).fold(
-    onSuccess = { accept(it) },
-    onFailure = { showError(it.message) }
-)
+// kiban
+val iban = Iban(input)
 ```
 
 ### Typed failures
 
-Catching `IllegalArgumentException` and reading `message` is no longer necessary. Failures carry a sealed type:
+Catching `IllegalArgumentException` and reading `message` is not necessary. Failures carry a sealed type:
 
 ``` kotlin
-when (val failure = Iban.parse(input).exceptionOrNull()) {
-    is IbanParseException.UnknownCountryCode -> failure.countryCode
-    is IbanParseException.WrongLength -> "${failure.actualLength} != ${failure.expectedLength}"
-    is IbanParseException.WrongChecksum -> "check digits do not match"
-    is IbanParseException.Malformed -> failure.kind.name
-    null -> "parsed successfully"
+try {
+    Iban(input)
+} catch (failure: IbanParseException) {
+    when (failure) {
+        is IbanParseException.UnknownCountryCode -> failure.countryCode
+        is IbanParseException.WrongLength -> "${failure.actualLength} != ${failure.expectedLength}"
+        is IbanParseException.WrongChecksum -> "check digits do not match"
+        is IbanParseException.Malformed -> failure.kind.name
+    }
 }
 ```
-
-`IbanParseException` extends `IllegalArgumentException`, so existing `catch` blocks around `getOrThrow()` keep
-working unchanged.
 
 ## Instance API
 
@@ -69,8 +94,8 @@ working unchanged.
 | --- | --- |
 | `iban.toPlainString()` | `iban.plain` |
 | `iban.toString()` | `iban.toString()` or `iban.pretty` (unchanged behaviour: spaced formatting) |
-| `IBAN.toPretty(input)` | `Iban.format(input)` |
-| `IBAN.toPlain(input)` | `Iban.toPlain(input)` |
+| `IBAN.toPretty(input)` | no replacement — parse with `Iban(input)`, then use `iban.pretty` |
+| `IBAN.toPlain(input)` | no replacement — parse with `Iban(input)`, then use `iban.plain` |
 | `iban.countryCode` | `iban.countryCode` |
 | `iban.checkDigits` | `iban.checkDigits` |
 | `iban.isSEPA` / `iban.isInSwiftRegistry` | unchanged |
@@ -99,14 +124,14 @@ ground, and `?:` replaces `orElse`.
 
 ## Composition
 
-`Iban.compose` also returns a `Result`:
+`Iban.compose` throws on invalid input, same as `Iban(input)`:
 
 ``` kotlin
 // before
 val iban = IBAN.compose("BI", "10000100010000332045181")
 
 // now
-val iban = Iban.compose("BI", "10000100010000332045181").getOrThrow()
+val iban = Iban.compose("BI", "10000100010000332045181")
 ```
 
 If you used `compose` on kiban 0.3.0, note that it was broken for any country whose check digits are 10 or

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Artifacts are published to Maven Central.
 
 ``` kotlin
 dependencies {
-    implementation("nl.bijdorpstudio.kiban:kiban:0.4.0")
+    implementation("nl.bijdorpstudio.kiban:kiban:0.5.0")
 }
 ```
 
@@ -43,7 +43,7 @@ In a multiplatform project, add it to `commonMain`:
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("nl.bijdorpstudio.kiban:kiban:0.4.0")
+            implementation("nl.bijdorpstudio.kiban:kiban:0.5.0")
         }
     }
 }
@@ -53,30 +53,31 @@ Supported targets: JVM, Android, `js` (Node.js and browser), `wasmJs` (Node.js a
 
 ## Use
 
-Parsing returns a `kotlin.Result`, so invalid input is a value rather than an exception. Nothing in the library throws for bad user input.
+Parsing is strict: invalid input throws a typed `IbanParseException`, so you don't need to unwrap a
+`Result` for the common case. The exception-free `toIbanOrNull()` and `isValidIban()` are there for
+when you want to check input without paying for a stack trace.
 
 ``` kotlin
-    // Parse returns Result<Iban>.
-    val iban: Iban = Iban.parse( "NL91ABNA0417164300" ).getOrThrow()
+    // The primary entry point. Throws IbanParseException on invalid input.
+    val iban: Iban = Iban( "NL91ABNA0417164300" )
 
-    // Handle failure without exceptions.
-    Iban.parse( input ).fold(
-        onSuccess = { accept( it ) },
-        onFailure = { showError( it.message ) }
-    )
+    // Or use the String extension; same throwing behaviour.
+    val parsed: Iban = "NL91ABNA0417164300".toIban()
 
-    // Or use the String extensions.
-    val parsed: Result<Iban> = "NL91ABNA0417164300".toIban()
+    // Exception-free fast paths.
     val orNull: Iban? = "NL91ABNA0417164301".toIbanOrNull() // null, check digits are wrong
     val isValid: Boolean = "NL91ABNA0417164300".isValidIban() // true
 
     // Failures carry a typed reason, so you never have to match on messages.
-    when ( val failure = Iban.parse( input ).exceptionOrNull() ) {
-        is IbanParseException.UnknownCountryCode -> reportUnknown( failure.countryCode )
-        is IbanParseException.WrongLength -> reportLength( failure.expectedLength, failure.actualLength )
-        is IbanParseException.WrongChecksum -> reportChecksum()
-        is IbanParseException.Malformed -> reportMalformed( failure.kind )
-        null -> Unit // parsed successfully
+    try {
+        Iban( input )
+    } catch ( failure: IbanParseException ) {
+        when ( failure ) {
+            is IbanParseException.UnknownCountryCode -> reportUnknown( failure.countryCode )
+            is IbanParseException.WrongLength -> reportLength( failure.expectedLength, failure.actualLength )
+            is IbanParseException.WrongChecksum -> reportChecksum()
+            is IbanParseException.Malformed -> reportMalformed( failure.kind )
+        }
     }
 
     // toString() emits standard formatting, plain is compact.
@@ -84,7 +85,7 @@ Parsing returns a `kotlin.Result`, so invalid input is a value rather than an ex
     val plain = iban.plain // "NL91ABNA0417164300"
 
     // Input may be formatted.
-    val anotherIban = Iban.parse( "BE68 5390 0754 7034" ).getOrThrow()
+    val anotherIban = Iban( "BE68 5390 0754 7034" )
 
     // Iban implements Comparable<T>.
     val ibans = getListOfIBANs()
@@ -98,14 +99,14 @@ Parsing returns a `kotlin.Result`, so invalid input is a value rather than an ex
     val candidate = "GB29 NWBK 6016 1331 9268 19"
     val valid = Modulo97.verifyCheckDigits( candidate ) // true
 
-    // Compose the IBAN for a country and BBAN; this also returns a Result.
-    Iban.compose( "BI", "10000100010000332045181" ).getOrThrow() // BI4210000100010000332045181
+    // Compose the IBAN for a country and BBAN; also throws on invalid input.
+    Iban.compose( "BI", "10000100010000332045181" ) // BI4210000100010000332045181
 
     // You can query whether an IBAN is of a SEPA-participating country
-    val isSepa = Iban.parse( candidate ).getOrThrow().isSEPA // true
+    val isSepa = Iban( candidate ).isSEPA // true
 
     // You can query whether an IBAN is in the SWIFT Registry
-    val isRegistered = Iban.parse( candidate ).getOrThrow().isInSwiftRegistry // true
+    val isRegistered = Iban( candidate ).isInSwiftRegistry // true
 
     // Modulo97 API methods take CharSequence, not just String.
     val builder = StringBuilder( "LU000019400644750000" )
@@ -124,15 +125,22 @@ Parsing returns a `kotlin.Result`, so invalid input is a value rather than an ex
     val branchId: String? = iban.branchIdentifier
 ```
 
-`Modulo97` is the one part of the library that still throws: its inputs are programmer-supplied, so a bad one is a contract violation rather than user input to be validated.
+`Modulo97` is the one part of the library that still throws unconditionally: its inputs are
+programmer-supplied, so a bad one is a contract violation rather than user input to be validated.
+`Iban`'s throwing entry points (`Iban(...)`, `Iban.compose(...)`, `String.toIban()`) are annotated
+`@Throws(IbanParseException::class)`, so Kotlin/Native's Objective-C exporter emits an `NSError**`
+out-parameter and Swift sees a normal `throws` function instead of the process aborting on an
+unannotated exception.
 
-Migrating from `java-iban` or from kiban 0.3.0 and earlier? See [MIGRATION.md](MIGRATION.md).
+Migrating from `java-iban`, from kiban 0.3.0 and earlier, or from the `Result`-returning 0.4.0 API?
+See [MIGRATION.md](MIGRATION.md).
 
 Every example above is walked through by [`samples/jvm-cli`](samples/jvm-cli), a runnable demo
 of the API; see [`samples/`](samples) for that and a Swift consumer exercising the library
 through Kotlin/Native's Objective-C interop — see
-[`docs/9-swift-interop-review.md`](docs/9-swift-interop-review.md) for what that review found
-and why kiban's `Result`-returning API needs a Swift-friendly companion surface before 1.0.
+[`docs/9-swift-interop-review.md`](docs/9-swift-interop-review.md) for the review that found the
+0.4.0 `Result`-returning API didn't survive the trip to Swift, which is what this strict,
+`@Throws`-annotated API is meant to fix.
 
 ## Design choices
 
@@ -153,9 +161,8 @@ I [(Barend)](https://github.com/barend) like the Joda-Time library, and I try to
 
 Adopted design choices from the Java library, plus:
 * Kotlinize the API so it is idiomatic for Kotlin users.
-* Parsing reports failure as `Result.failure` carrying a sealed `IbanParseException`, rather than by throwing. The exception type extends `IllegalArgumentException`, so `getOrThrow()` behaves exactly like the old throwing API, and callers who want typed errors can inspect the failure instead of matching on messages.
+* Parsing is strict and throws a sealed `IbanParseException` on invalid input, rather than returning a `Result`. The exception type extends `IllegalArgumentException`, and callers who want typed errors can catch it and inspect the failure instead of matching on messages. Every throwing entry point carries `@Throws(IbanParseException::class)`, which is load-bearing for Kotlin/Native's Objective-C interop: an exception escaping an unannotated function aborts the process there, rather than surfacing as a catchable Swift error.
 * `Modulo97` keeps throwing: it is a low-level utility whose errors indicate a contract violation, not invalid user input.
-* Deprecate old API and provide an automatic migration mechanism through `ReplaceWith`. The compat layer is kept until 1.0.
 * Zero dependencies: only the Kotlin standard library, which is what lets the library ship on every Kotlin target.
 
 ## References

--- a/docs/9-swift-interop-review.md
+++ b/docs/9-swift-interop-review.md
@@ -161,3 +161,38 @@ Designing the actual companion surface (naming, whether it lives in `commonMain`
 `@JvmName`/`@ObjCName` or as an Apple-target-only source set, what shape the error side takes)
 is real API design work and its own issue — this review's job was to answer *whether* one is
 needed and *why*, with real evidence, not to design it.
+
+## 0.5.0 follow-up: `@Throws` verified for real (2026-08-09)
+
+#100 replaced the `Result<Iban>` shape with strict, `@Throws(IbanParseException::class)`-annotated
+parsing. Its own Verification section flagged the Swift catch shape as unconfirmed — that annotated
+functions surface to Swift as `throws`, but whether the Kotlin exception arrives usably. Confirmed
+on `feature/issue-100-strict-throwing-api` via `ios-interop-verify.yml`, building and running
+`samples/swift-console` against a real `Kiban.xcframework`.
+
+- The generated header confirms the documented NSError-out-param shape:
+  `invoke(input:)`, `compose(countryCode:bban:)` and the top-level `IbanKt.toIban(...)` each carry
+  `error:(NSError * _Nullable * _Nullable)error`, with a Kotlin/Native-generated doc comment on
+  every one of them: *"This method converts instances of IbanParseException to errors. Other
+  uncaught Kotlin exceptions are fatal."*
+- Calling `IbanKt.toIban("not an iban")` from a Swift `do { try ... } catch { ... }` does **not**
+  crash the process — unlike the old, unannotated `valueOf`, which the original #9 review confirmed
+  SIGABRTs. The caught error prints as:
+  ```
+  Error Domain=KotlinException Code=0 "Characters at index 2 and 3 not both numeric. notaniban"
+  UserInfo={NSLocalizedDescription=Characters at index 2 and 3 not both numeric. notaniban,
+  KotlinException=nl.bijdorpstudio.kiban.IbanParseException.Malformed: Characters at index 2 and 3
+  not both numeric. notaniban, KotlinExceptionOrigin=}
+  ```
+  So the original #9 finding — "no programmatic access to the failure at all" — is closed for the
+  "does it crash" and "can Swift catch it" questions. **Still open, not exercised by this run**:
+  whether `error.userInfo["KotlinException"]` can be `as?`-downcast from Swift to the real
+  `IbanParseException.Malformed` type for typed access, versus only reading its string description.
+  That's the concrete next thing to verify before calling the companion-surface question (see
+  Recommendation, above) fully settled either way.
+- `Iban`'s companion `invoke`/`compose` are **not** surfaced as Swift initializers under this
+  interop path — they're `Iban.companion.invoke(input:)` / `Iban.companion.compose(countryCode:bban:)`
+  (`companion` is a generated static property on the `KibanIban` ObjC class). `operator fun invoke`
+  gets no special Swift-init treatment here, which is why `samples/swift-console` calls the
+  top-level `IbanKt.toIban(...)` for its throwing-path demo instead of guessing at `Iban(...)`
+  syntax.

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -1,14 +1,10 @@
 public final class nl/bijdorpstudio/kiban/CountryCodes {
 	public static final field INSTANCE Lnl/bijdorpstudio/kiban/CountryCodes;
-	public static final field lastUpdateDateString Ljava/lang/String;
 	public static final field lastUpdateRevision Ljava/lang/String;
-	public final fun getBankIdentifier (Lnl/bijdorpstudio/kiban/Iban;)Ljava/lang/String;
-	public final fun getBranchIdentifier (Lnl/bijdorpstudio/kiban/Iban;)Ljava/lang/String;
 	public final fun getKnownCountryCodes ()Ljava/util/Collection;
 	public final fun getLONGEST_IBAN_LENGTH ()I
 	public final fun getLastUpdateDate ()Lkotlin/time/Instant;
 	public final fun getLength (Ljava/lang/CharSequence;)Ljava/lang/Integer;
-	public final fun getLengthForCountryCode (Ljava/lang/CharSequence;)I
 	public final fun getSHORTEST_IBAN_LENGTH ()I
 	public final fun isInSwiftRegistry (Ljava/lang/CharSequence;)Z
 	public final fun isKnownCountryCode (Ljava/lang/CharSequence;)Z
@@ -18,6 +14,7 @@ public final class nl/bijdorpstudio/kiban/CountryCodes {
 public final class nl/bijdorpstudio/kiban/Iban : java/lang/Comparable {
 	public static final field Companion Lnl/bijdorpstudio/kiban/Iban$Companion;
 	public static final field SHORTEST_POSSIBLE_IBAN I
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Lnl/bijdorpstudio/kiban/Iban;)I
 	public fun equals (Ljava/lang/Object;)Z
@@ -30,23 +27,17 @@ public final class nl/bijdorpstudio/kiban/Iban : java/lang/Comparable {
 	public fun hashCode ()I
 	public final fun isInSwiftRegistry ()Z
 	public final fun isSEPA ()Z
-	public final fun toPlainString ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class nl/bijdorpstudio/kiban/Iban$Companion {
-	public final fun compose-gIAlu-s (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/Object;
-	public final fun format (Ljava/lang/CharSequence;)Ljava/lang/String;
-	public final fun invoke-IoAF18A (Ljava/lang/CharSequence;)Ljava/lang/Object;
-	public final fun parse-IoAF18A (Ljava/lang/CharSequence;)Ljava/lang/Object;
-	public final fun toPlain (Ljava/lang/CharSequence;)Ljava/lang/String;
-	public final fun toPretty (Ljava/lang/CharSequence;)Ljava/lang/String;
-	public final fun valueOf (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
+	public final fun compose (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
+	public final fun invoke (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
 }
 
 public final class nl/bijdorpstudio/kiban/IbanKt {
 	public static final fun isValidIban (Ljava/lang/String;)Z
-	public static final fun toIban (Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun toIban (Ljava/lang/String;)Lnl/bijdorpstudio/kiban/Iban;
 	public static final fun toIbanOrNull (Ljava/lang/String;)Lnl/bijdorpstudio/kiban/Iban;
 }
 

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -27,20 +27,14 @@ final class nl.bijdorpstudio.kiban/Iban : kotlin/Comparable<nl.bijdorpstudio.kib
     final fun compareTo(nl.bijdorpstudio.kiban/Iban): kotlin/Int // nl.bijdorpstudio.kiban/Iban.compareTo|compareTo(nl.bijdorpstudio.kiban.Iban){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // nl.bijdorpstudio.kiban/Iban.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // nl.bijdorpstudio.kiban/Iban.hashCode|hashCode(){}[0]
-    final fun toPlainString(): kotlin/String // nl.bijdorpstudio.kiban/Iban.toPlainString|toPlainString(){}[0]
     final fun toString(): kotlin/String // nl.bijdorpstudio.kiban/Iban.toString|toString(){}[0]
 
     final object Companion { // nl.bijdorpstudio.kiban/Iban.Companion|null[0]
         final const val SHORTEST_POSSIBLE_IBAN // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN|{}SHORTEST_POSSIBLE_IBAN[0]
             final fun <get-SHORTEST_POSSIBLE_IBAN>(): kotlin/Int // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN.<get-SHORTEST_POSSIBLE_IBAN>|<get-SHORTEST_POSSIBLE_IBAN>(){}[0]
 
-        final fun compose(kotlin/CharSequence, kotlin/CharSequence): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/Iban.Companion.compose|compose(kotlin.CharSequence;kotlin.CharSequence){}[0]
-        final fun format(kotlin/CharSequence): kotlin/String // nl.bijdorpstudio.kiban/Iban.Companion.format|format(kotlin.CharSequence){}[0]
-        final fun invoke(kotlin/CharSequence): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/Iban.Companion.invoke|invoke(kotlin.CharSequence){}[0]
-        final fun parse(kotlin/CharSequence): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/Iban.Companion.parse|parse(kotlin.CharSequence){}[0]
-        final fun toPlain(kotlin/CharSequence): kotlin/String // nl.bijdorpstudio.kiban/Iban.Companion.toPlain|toPlain(kotlin.CharSequence){}[0]
-        final fun toPretty(kotlin/CharSequence): kotlin/String // nl.bijdorpstudio.kiban/Iban.Companion.toPretty|toPretty(kotlin.CharSequence){}[0]
-        final fun valueOf(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.valueOf|valueOf(kotlin.CharSequence){}[0]
+        final fun compose(kotlin/CharSequence, kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.compose|compose(kotlin.CharSequence;kotlin.CharSequence){}[0]
+        final fun invoke(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.invoke|invoke(kotlin.CharSequence){}[0]
     }
 }
 
@@ -92,8 +86,6 @@ sealed class nl.bijdorpstudio.kiban/IbanParseException : kotlin/IllegalArgumentE
 }
 
 final object nl.bijdorpstudio.kiban/CountryCodes { // nl.bijdorpstudio.kiban/CountryCodes|null[0]
-    final const val lastUpdateDateString // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDateString|{}lastUpdateDateString[0]
-        final fun <get-lastUpdateDateString>(): kotlin/String // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDateString.<get-lastUpdateDateString>|<get-lastUpdateDateString>(){}[0]
     final const val lastUpdateRevision // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateRevision|{}lastUpdateRevision[0]
         final fun <get-lastUpdateRevision>(): kotlin/String // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateRevision.<get-lastUpdateRevision>|<get-lastUpdateRevision>(){}[0]
 
@@ -106,10 +98,7 @@ final object nl.bijdorpstudio.kiban/CountryCodes { // nl.bijdorpstudio.kiban/Cou
     final val lastUpdateDate // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate|{}lastUpdateDate[0]
         final fun <get-lastUpdateDate>(): kotlin.time/Instant // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate.<get-lastUpdateDate>|<get-lastUpdateDate>(){}[0]
 
-    final fun getBankIdentifier(nl.bijdorpstudio.kiban/Iban): kotlin/String? // nl.bijdorpstudio.kiban/CountryCodes.getBankIdentifier|getBankIdentifier(nl.bijdorpstudio.kiban.Iban){}[0]
-    final fun getBranchIdentifier(nl.bijdorpstudio.kiban/Iban): kotlin/String? // nl.bijdorpstudio.kiban/CountryCodes.getBranchIdentifier|getBranchIdentifier(nl.bijdorpstudio.kiban.Iban){}[0]
     final fun getLength(kotlin/CharSequence): kotlin/Int? // nl.bijdorpstudio.kiban/CountryCodes.getLength|getLength(kotlin.CharSequence){}[0]
-    final fun getLengthForCountryCode(kotlin/CharSequence): kotlin/Int // nl.bijdorpstudio.kiban/CountryCodes.getLengthForCountryCode|getLengthForCountryCode(kotlin.CharSequence){}[0]
     final fun isInSwiftRegistry(kotlin/CharSequence): kotlin/Boolean // nl.bijdorpstudio.kiban/CountryCodes.isInSwiftRegistry|isInSwiftRegistry(kotlin.CharSequence){}[0]
     final fun isKnownCountryCode(kotlin/CharSequence): kotlin/Boolean // nl.bijdorpstudio.kiban/CountryCodes.isKnownCountryCode|isKnownCountryCode(kotlin.CharSequence){}[0]
     final fun isSEPACountry(kotlin/CharSequence): kotlin/Boolean // nl.bijdorpstudio.kiban/CountryCodes.isSEPACountry|isSEPACountry(kotlin.CharSequence){}[0]
@@ -123,5 +112,5 @@ final object nl.bijdorpstudio.kiban/Modulo97 { // nl.bijdorpstudio.kiban/Modulo9
 }
 
 final fun (kotlin/String).nl.bijdorpstudio.kiban/isValidIban(): kotlin/Boolean // nl.bijdorpstudio.kiban/isValidIban|isValidIban@kotlin.String(){}[0]
-final fun (kotlin/String).nl.bijdorpstudio.kiban/toIban(): kotlin/Result<nl.bijdorpstudio.kiban/Iban> // nl.bijdorpstudio.kiban/toIban|toIban@kotlin.String(){}[0]
+final fun (kotlin/String).nl.bijdorpstudio.kiban/toIban(): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/toIban|toIban@kotlin.String(){}[0]
 final fun (kotlin/String).nl.bijdorpstudio.kiban/toIbanOrNull(): nl.bijdorpstudio.kiban/Iban? // nl.bijdorpstudio.kiban/toIbanOrNull|toIbanOrNull@kotlin.String(){}[0]

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
@@ -71,10 +71,7 @@ object CountryCodes {
      * @param iban an iban to evaluate. Cannot be null.
      * @return the bank ID for this IBAN, or `null` if unknown.
      */
-    @Deprecated("Use Iban.bankIdentifier instead", ReplaceWith("iban.bankIdentifier"))
-    fun getBankIdentifier(iban: Iban): String? = getBankIdentifierInternal(iban)
-
-    internal fun getBankIdentifierInternal(iban: Iban): String? {
+    internal fun getBankIdentifier(iban: Iban): String? {
         val index: Int = indexOf(iban.countryCode)
         if (index > -1) {
             val data: Int = BANK_CODE_BRANCH_CODE[index]
@@ -91,10 +88,7 @@ object CountryCodes {
      * @param iban an iban to evaluate. Cannot be null.
      * @return the branch ID for this IBAN, or `null` if unknown.
      */
-    @Deprecated("Use Iban.branchIdentifier instead", ReplaceWith("iban.branchIdentifier"))
-    fun getBranchIdentifier(iban: Iban): String? = getBranchIdentifierInternal(iban)
-
-    internal fun getBranchIdentifierInternal(iban: Iban): String? {
+    internal fun getBranchIdentifier(iban: Iban): String? {
         val index: Int = indexOf(iban.countryCode)
         if (index > -1) {
             val data: Int = BANK_CODE_BRANCH_CODE[index]
@@ -121,16 +115,6 @@ object CountryCodes {
         }
         return null
     }
-
-    /**
-     * Returns the IBAN length for a given country code.
-     *
-     * @param countryCode a non-null, uppercase, two-character country code.
-     * @return the IBAN length for the given country, or -1 if the input is not a known,
-     *   two-character country code.
-     */
-    @Deprecated("Use getLength instead", ReplaceWith("getLength(countryCode) ?: -1"))
-    fun getLengthForCountryCode(countryCode: CharSequence): Int = getLength(countryCode) ?: -1
 
     /**
      * Returns whether the given country code is in SEPA.
@@ -182,15 +166,7 @@ object CountryCodes {
         get() = Instant.parse("${LAST_UPDATE_DATE}T00:00:00Z")
 
     /**
-     * Returns the date that the IBAN reference data was last updated.
-     *
-     * @return the last update date of the reference data in this library.
-     */
-    @Deprecated("Use lastUpdateDate property instead", ReplaceWith("lastUpdateDate"))
-    const val lastUpdateDateString: String = LAST_UPDATE_DATE
-
-    /**
-     * Returns the version information of the SWIFT IBAN Registry used on [.lastUpdateDateString].
+     * Returns the version information of the SWIFT IBAN Registry used on [.lastUpdateDate].
      *
      * @return revision information of the SWIFT IBAN Registry.
      */

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -15,8 +15,6 @@
 */
 package nl.bijdorpstudio.kiban
 
-import kotlin.Result.Companion.failure
-import nl.bijdorpstudio.kiban.Iban.Companion.parse
 import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
 
 /**
@@ -33,13 +31,12 @@ import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
  *   International Bank Account Number</a>
  * @author Barend Garvelink https://github.com/barend
  *
- * Instances can only be obtained through [Iban.parse] or [Iban.compose], which validate the input
- * and report failures as a [Result] carrying an [IbanParseException]. Construction itself never
- * fails.
+ * Instances can only be obtained through [Iban.invoke] (`Iban(input)`) or [Iban.compose], which
+ * validate the input and throw an [IbanParseException] on failure. Construction itself never fails.
  *
  * @since 1.0.0
  */
-class Iban internal constructor(internal val value: String) : Comparable<Iban> {
+class Iban private constructor(internal val value: String) : Comparable<Iban> {
     /**
      * Whether or not this IBAN data is from the SWIFT IBAN Registry.
      *
@@ -58,8 +55,8 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
     val pretty: String by lazy(LazyThreadSafetyMode.NONE) { addSpaces(value) }
 
     /**
-     * Initializing constructor. Validation happens in [parse], so this constructor cannot fail. the
-     * IBAN value, without any white space, already validated by [parse].
+     * Initializing constructor. Validation happens before construction, so this constructor cannot
+     * fail. the IBAN value, without any white space, already validated by the caller.
      */
     init {
         val countryCode: String = value.substring(0, 2)
@@ -89,7 +86,7 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
      * @return the bank ID, or `null` if unknown for this country code.
      */
     val bankIdentifier: String?
-        get() = CountryCodes.getBankIdentifierInternal(this)
+        get() = CountryCodes.getBankIdentifier(this)
 
     /**
      * Returns the branch identifier embedded in the IBAN, if available.
@@ -97,7 +94,7 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
      * @return the branch ID, or `null` if unknown for this country code.
      */
     val branchIdentifier: String?
-        get() = CountryCodes.getBranchIdentifierInternal(this)
+        get() = CountryCodes.getBranchIdentifier(this)
 
     /**
      * Returns the IBAN without formatting.
@@ -106,14 +103,6 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
      */
     val plain: String
         get() = value
-
-    /**
-     * Returns the IBAN without formatting.
-     *
-     * @return the unformatted IBAN number.
-     */
-    @Deprecated("Use plain property instead", ReplaceWith("plain"))
-    fun toPlainString(): String = plain
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -142,11 +131,15 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
          *
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with
          *   (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
-         * @return a [Result] holding the parsed and validated IBAN object, or an
-         *   [IbanParseException] describing why the input was rejected.
-         * @see [parse]
+         * @return the parsed and validated IBAN object.
+         * @throws IbanParseException describing why the input was rejected.
          */
-        operator fun invoke(input: CharSequence): Result<Iban> = parse(input)
+        @Throws(IbanParseException::class)
+        operator fun invoke(input: CharSequence): Iban =
+            when (val rejection = validate(input)) {
+                null -> Iban(toPlain(input))
+                else -> throw rejection.toException()
+            }
 
         /**
          * The technically shortest possible IBAN. See [CountryCodes.SHORTEST_IBAN_LENGTH] for the
@@ -155,29 +148,16 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
         const val SHORTEST_POSSIBLE_IBAN: Int = 5
 
         /**
-         * Parses the given string into an IBAN object and confirms the check digits.
-         *
-         * This is the primary entry point of the library. It never throws for invalid user input;
-         * failures are returned as a [Result.failure] carrying an [IbanParseException]. Use
-         * [Result.getOrThrow] for the semantics of the deprecated throwing API.
-         *
-         * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with
-         *   (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
-         * @return a [Result] holding the parsed and validated IBAN object, or an
-         *   [IbanParseException] describing why the input was rejected.
-         * @see [IbanParseException]
+         * Wraps an already-validated, whitespace-stripped IBAN string, without paying for
+         * validation a second time.
          */
-        fun parse(input: CharSequence): Result<Iban> =
-            when (val rejection = validate(input)) {
-                null -> Result.success(Iban(toPlain(input)))
-                else -> failure(rejection.toException())
-            }
+        internal fun ofValidated(plain: String): Iban = Iban(plain)
 
         /**
          * Validates the given input without constructing an [IbanParseException], so that
          * [String.isValidIban] and [String.toIbanOrNull] can reject invalid input without paying
-         * for a captured stack trace. [parse] builds on this and constructs the exception only when
-         * a caller actually needs one.
+         * for a captured stack trace. [invoke] builds on this and constructs the exception only
+         * when a caller actually needs one.
          *
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with
          *   (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
@@ -226,28 +206,16 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
         }
 
         /**
-         * Parses the given string into an IBAN object and confirms the check digits, throwing on
-         * invalid input.
-         *
-         * @param input the input, which can be either plain ("CC11ABCD123...") or formatted ("CC11
-         *   ABCD 123. ..").
-         * @return the parsed and validated IBAN object.
-         * @throws [IllegalArgumentException] if the input is in some way invalid.
-         * @see [parse]
-         */
-        @Deprecated("Use parse() instead", ReplaceWith("parse(input).getOrThrow()"))
-        fun valueOf(input: CharSequence): Iban = parse(input).getOrThrow()
-
-        /**
          * Composes an IBAN from the given country code and basic bank account number, calculating
          * the check digits.
          *
          * @param countryCode the country code.
          * @param bban the BBAN.
-         * @return a [Result] holding the IBAN object composed of the given parts, or an
-         *   [IbanParseException] describing why the parts were rejected.
+         * @return the IBAN object composed of the given parts.
+         * @throws IbanParseException describing why the parts were rejected.
          */
-        fun compose(countryCode: CharSequence, bban: CharSequence): Result<Iban> {
+        @Throws(IbanParseException::class)
+        fun compose(countryCode: CharSequence, bban: CharSequence): Iban {
             val sb =
                 StringBuilder(CountryCodes.LONGEST_IBAN_LENGTH)
                     .append(countryCode)
@@ -257,16 +225,14 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
                 try {
                     Modulo97.calculateCheckDigits(sb)
                 } catch (e: IllegalArgumentException) {
-                    return failure(
-                        IbanParseException.Malformed(
-                            toPlain(sb),
-                            Kind.INVALID_STRUCTURE,
-                            e.message ?: "Cannot calculate check digits for $sb",
-                        )
+                    throw IbanParseException.Malformed(
+                        toPlain(sb),
+                        Kind.INVALID_STRUCTURE,
+                        e.message ?: "Cannot calculate check digits for $sb",
                     )
                 }
             sb.setRange(2, 4, checkDigits.toString().padStart(2, '0'))
-            return parse(sb)
+            return invoke(sb)
         }
 
         /**
@@ -275,30 +241,8 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
          * @param input possibly pretty printed IBAN
          * @return plain IBAN
          */
-        fun toPlain(input: CharSequence): String = input.filter { !it.isWhitespace() }.toString()
-
-        /**
-         * Ensures that the input is pretty printed by first removing any spaces the String might
-         * contain and then adding spaces in the right places.
-         *
-         * This can be useful when prompting a user to correct wrong input
-         *
-         * @param input plain or pretty printed IBAN
-         * @return pretty printed IBAN
-         */
-        fun format(input: CharSequence): String = addSpaces(toPlain(input))
-
-        /**
-         * Ensures that the input is pretty printed by first removing any spaces the String might
-         * contain and then adding spaces in the right places.
-         *
-         * This can be useful when prompting a user to correct wrong input
-         *
-         * @param input plain or pretty printed IBAN
-         * @return pretty printed IBAN
-         */
-        @Deprecated("Use format() instead", ReplaceWith("format(input)"))
-        fun toPretty(input: CharSequence): String = format(input)
+        internal fun toPlain(input: CharSequence): String =
+            input.filter { !it.isWhitespace() }.toString()
 
         /**
          * Converts a plain to a pretty printed IBAN
@@ -306,28 +250,36 @@ class Iban internal constructor(internal val value: String) : Comparable<Iban> {
          * @param value plain iban
          * @return pretty printed IBAN
          */
-        private fun addSpaces(value: CharSequence): String = value.chunked(4).joinToString(" ")
+        internal fun addSpaces(value: CharSequence): String = value.chunked(4).joinToString(" ")
     }
 }
 
 /**
  * Parses the given string into an IBAN object and confirms the check digits.
  *
- * @return a [Result] holding the parsed and validated IBAN object, or an [IbanParseException]
- *   describing why the input was rejected.
- * @see Iban.parse
+ * @return the parsed and validated IBAN object.
+ * @throws IbanParseException describing why the input was rejected.
+ * @see Iban.invoke
  */
-fun String.toIban(): Result<Iban> = parse(this)
+@Throws(IbanParseException::class)
+fun String.toIban(): Iban =
+    when (val rejection = Iban.validate(this)) {
+        // Must stay ofValidated, not Iban(...): this is a top-level function, so Iban(...) here
+        // would resolve to invoke and re-run validate() on an input already known to be valid.
+        null -> Iban.ofValidated(Iban.toPlain(this))
+        else -> throw rejection.toException()
+    }
 
 /**
  * Parses the given string into an IBAN object and confirms the check digits, discarding the failure
  * detail.
  *
  * @return the parsed and validated IBAN object, or `null` if the input is in some way invalid.
- * @see Iban.parse
+ * @see Iban.invoke
  */
 fun String.toIbanOrNull(): Iban? =
-    if (Iban.validate(this) == null) Iban(Iban.toPlain(this)) else null
+    // Must stay ofValidated, not Iban(...): see the comment on toIban above.
+    if (Iban.validate(this) == null) Iban.ofValidated(Iban.toPlain(this)) else null
 
 /** Returns whether the given string is a valid IBAN. */
 fun String.isValidIban(): Boolean = Iban.validate(this) == null

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -16,12 +16,9 @@
 package nl.bijdorpstudio.kiban
 
 /**
- * The failure carried by the [Result] of a failed [Iban.parse] or [Iban.compose].
- *
- * Instances are never thrown by the library itself; they are wrapped in [Result.failure] so that
- * callers can decide whether to inspect the failure or to rethrow it with [Result.getOrThrow].
- * Extending [IllegalArgumentException] keeps the semantics of the deprecated throwing API
- * identical.
+ * Thrown by a failed [Iban.invoke] (`Iban(input)`), [Iban.compose] or [String.toIban] to describe
+ * why the input was rejected. Extending [IllegalArgumentException] means callers who only care that
+ * parsing failed don't need to catch this type specifically.
  *
  * @property input the offending input, with any white space removed.
  */
@@ -101,7 +98,7 @@ sealed class IbanParseException(
  * Carries the same information as [IbanParseException] without paying for a captured stack trace,
  * so that the non-throwing validation paths ([String.isValidIban] and [String.toIbanOrNull]) can
  * reject input without allocating a [Throwable]. [toException] builds the actual
- * [IbanParseException] for callers that need it, such as [Iban.parse].
+ * [IbanParseException] for callers that need it, such as [Iban.invoke].
  */
 internal sealed class Rejection(val input: String) {
 

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesParameterizedTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesParameterizedTest.kt
@@ -32,8 +32,7 @@ class CountryCodesParameterizedTest {
     @Test
     fun `Length for country code should return correct value`() {
         countriesTestDataTable.forAll { testData ->
-            val lengthForCountryCode =
-                CountryCodes.getLengthForCountryCode(testData.plain.substring(0, 2))
+            val lengthForCountryCode = CountryCodes.getLength(testData.plain.substring(0, 2)) ?: -1
             assertThat(lengthForCountryCode).isEqualTo(testData.plain.length)
         }
     }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
@@ -20,6 +20,7 @@ import assertk.assertions.isBetween
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -63,8 +64,8 @@ class CountryCodesTest {
     }
 
     @Test
-    fun `getLengthForCountryCode returns -1 for unknown country code`() {
-        assertThat(CountryCodes.getLengthForCountryCode("XX")).isEqualTo(-1)
+    fun `getLength returns null for unknown country code`() {
+        assertThat(CountryCodes.getLength("XX")).isNull()
     }
 
     @Test

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldTest.kt
@@ -28,16 +28,16 @@ class CountryCodesIbanFieldsTest {
     @Test
     fun `Should extract bank identifier`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val iban = Iban.parse(td.plain).getOrThrow()
-            assertThat(CountryCodes.getBankIdentifier(iban)).isEqualTo(td.bank)
+            val iban = Iban(td.plain)
+            assertThat(iban.bankIdentifier).isEqualTo(td.bank)
         }
     }
 
     @Test
     fun `Should extract branch identifier`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val iban = Iban.parse(td.plain).getOrThrow()
-            assertThat(CountryCodes.getBranchIdentifier(iban)).isEqualTo(td.branch)
+            val iban = Iban(td.plain)
+            assertThat(iban.branchIdentifier).isEqualTo(td.branch)
         }
     }
 }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
@@ -27,8 +27,8 @@ class IbanInternationalTest {
     @Test
     fun `Parse should accept plain form`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { testData ->
-            val iban = Iban.parse(testData.plain).getOrThrow()
-            assertThat(iban.toPlainString()).isEqualTo(testData.plain)
+            val iban = Iban(testData.plain)
+            assertThat(iban.plain).isEqualTo(testData.plain)
             assertThat(iban.toString()).isEqualTo(testData.pretty)
         }
     }
@@ -36,8 +36,8 @@ class IbanInternationalTest {
     @Test
     fun `Parse should accept pretty printed form`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val iban = Iban.parse(td.pretty).getOrThrow()
-            assertThat(iban.toPlainString()).isEqualTo(td.plain)
+            val iban = Iban(td.pretty)
+            assertThat(iban.plain).isEqualTo(td.plain)
             assertThat(iban.toString()).isEqualTo(td.pretty)
         }
     }
@@ -50,29 +50,28 @@ class IbanInternationalTest {
                     countryCode = td.plain.substring(0, 2),
                     bban = td.plain.substring(4),
                 )
-            assertThat(composed.getOrThrow()).isEqualTo(Iban.parse(td.plain).getOrThrow())
+            assertThat(composed).isEqualTo(Iban(td.plain))
         }
     }
 
     @Test
     fun `Check is registered IBAN`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            assertThat(Iban.parse(td.plain).getOrThrow().isInSwiftRegistry).isEqualTo(td.swift)
+            assertThat(Iban(td.plain).isInSwiftRegistry).isEqualTo(td.swift)
         }
     }
 
     @Test
     fun `Check is SEPA country`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            assertThat(Iban.parse(td.plain).getOrThrow().isSEPA).isEqualTo(td.sepa)
+            assertThat(Iban(td.plain).isSEPA).isEqualTo(td.sepa)
         }
     }
 
     @Test
     fun `Get length for country code should return correct value`() {
         CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val lengthForCountryCode =
-                CountryCodes.getLengthForCountryCode(td.plain.substring(0, 2))
+            val lengthForCountryCode = CountryCodes.getLength(td.plain.substring(0, 2)) ?: -1
             assertThat(lengthForCountryCode).isEqualTo(td.plain.length)
         }
     }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -18,7 +18,6 @@ package nl.bijdorpstudio.kiban
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
-import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
@@ -26,27 +25,31 @@ import assertk.assertions.prop
 import assertk.tableOf
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlin.test.fail
 
 /** Miscellaneous tests for the [Iban] class. */
 class IbanTest {
     @Test
     fun `Operator invoke should parse IBAN`() {
-        // Called through the companion explicitly: inside the library module the internal
-        // constructor would win.
-        val iban = Iban.Companion.invoke(VALID_IBAN).getOrThrow()
+        // Called through the companion explicitly: inside the library module the private
+        // constructor would win over invoke for an exact String argument.
+        val iban = Iban.Companion.invoke(VALID_IBAN)
         assertThat(iban.plain).isEqualTo(VALID_IBAN)
+    }
+
+    @Test
+    fun `Operator invoke should throw for invalid input`() {
+        assertFailsWith<IbanParseException.WrongChecksum> { Iban(INVALID_IBAN) }
     }
 
     @Test
     fun `toIban extension should parse IBAN`() {
-        val iban = VALID_IBAN.toIban().getOrThrow()
+        val iban = VALID_IBAN.toIban()
         assertThat(iban.plain).isEqualTo(VALID_IBAN)
     }
 
     @Test
-    fun `toIban extension should return failure for invalid IBAN`() {
-        assertThat(INVALID_IBAN.toIban().failure()).isInstanceOf<IbanParseException.WrongChecksum>()
+    fun `toIban extension should throw for invalid IBAN`() {
+        assertFailsWith<IbanParseException.WrongChecksum> { INVALID_IBAN.toIban() }
     }
 
     @Test
@@ -70,7 +73,7 @@ class IbanTest {
     }
 
     @Test
-    fun `isValidIban and toIbanOrNull should agree with parse for every rejection kind`() {
+    fun `isValidIban and toIbanOrNull should agree with invoke for every rejection kind`() {
         listOf(
                 "",
                 "Shenanigans!",
@@ -85,7 +88,7 @@ class IbanTest {
                 VALID_IBAN,
             )
             .forEach { input ->
-                val expectedSuccess = Iban.parse(input).isSuccess
+                val expectedSuccess = runCatching { Iban(input) }.isSuccess
 
                 assertThat(input.isValidIban(), "isValidIban for '$input'")
                     .isEqualTo(expectedSuccess)
@@ -96,124 +99,111 @@ class IbanTest {
 
     @Test
     fun `Valid IBAN should return country code`() {
-        assertThat(Iban.parse(VALID_IBAN).getOrThrow().countryCode).isEqualTo("NL")
+        assertThat(Iban(VALID_IBAN).countryCode).isEqualTo("NL")
     }
 
     @Test
     fun `Valid IBAN should return check digits`() {
-        assertThat(Iban.parse(VALID_IBAN).getOrThrow().checkDigits).isEqualTo("03")
+        assertThat(Iban(VALID_IBAN).checkDigits).isEqualTo("03")
     }
 
     @Test
-    fun `valueOf should accept toString output of valid IBAN`() {
-        val original = Iban.parse(VALID_IBAN).getOrThrow()
-        val copy = Iban.valueOf(original.toString())
+    fun `Invoke should accept toString output of valid IBAN`() {
+        val original = Iban(VALID_IBAN)
+        val copy = Iban(original.toString())
         assertThat(copy).isEqualTo(original)
     }
 
     @Test
-    fun `valueOf should throw for invalid input`() {
-        assertFailsWith<IbanParseException.WrongChecksum> { Iban.valueOf(INVALID_IBAN) }
+    fun `Invoke should reject empty input`() {
+        assertThat(malformedKind { Iban("") }).isEqualTo(IbanParseException.Malformed.Kind.EMPTY)
     }
 
     @Test
-    fun `Parse should reject empty input`() {
-        assertThat(Iban.parse("").malformedKind())
-            .isEqualTo(IbanParseException.Malformed.Kind.EMPTY)
-    }
+    fun `Invoke should reject invalid input`() {
+        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("Shenanigans!") }
 
-    @Test
-    fun `Parse should reject invalid input`() {
-        val failure = Iban.parse("Shenanigans!").failure()
-
-        assertThat((failure as? IbanParseException.Malformed)?.kind)
+        assertThat(failure.kind)
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
         assertThat(failure.message)
             .isEqualTo("Input begins or ends in an invalid character: Shenanigans!")
     }
 
     @Test
-    fun `Parse should reject leading whitespace`() {
-        val failure = Iban.parse(" $VALID_IBAN").failure()
+    fun `Invoke should reject leading whitespace`() {
+        val failure = assertFailsWith<IbanParseException.Malformed> { Iban(" $VALID_IBAN") }
 
-        assertThat((failure as? IbanParseException.Malformed)?.kind)
+        assertThat(failure.kind)
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
         assertThat(failure.message)
             .isEqualTo("Input begins or ends in an invalid character:  $VALID_IBAN")
     }
 
     @Test
-    fun `Parse should reject trailing whitespace`() {
-        val failure = Iban.parse("$VALID_IBAN ").failure()
+    fun `Invoke should reject trailing whitespace`() {
+        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("$VALID_IBAN ") }
 
-        assertThat((failure as? IbanParseException.Malformed)?.kind)
+        assertThat(failure.kind)
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
         assertThat(failure.message)
             .isEqualTo("Input begins or ends in an invalid character: $VALID_IBAN ")
     }
 
     @Test
-    fun `Parse should reject too short input`() {
-        val failure = Iban.parse("NL03").failure()
+    fun `Invoke should reject too short input`() {
+        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("NL03") }
 
-        assertThat((failure as? IbanParseException.Malformed)?.kind)
-            .isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
+        assertThat(failure.kind).isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
         assertThat(failure.message).isEqualTo("Length is too short to be an IBAN: NL03")
     }
 
     @Test
-    fun `Parse should reject non numeric check digits`() {
-        val failure = Iban.parse("NLAB0143267469").failure()
+    fun `Invoke should reject non numeric check digits`() {
+        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("NLAB0143267469") }
 
-        assertThat((failure as? IbanParseException.Malformed)?.kind)
+        assertThat(failure.kind)
             .isEqualTo(IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS)
         assertThat(failure.message)
             .isEqualTo("Characters at index 2 and 3 not both numeric. NLAB0143267469")
     }
 
     @Test
-    fun `Parse should reject unsupported characters`() {
+    fun `Invoke should reject unsupported characters`() {
         val invalidCharacter = VALID_IBAN.replaceRange(6, 7, "_")
 
-        assertThat(Iban.parse(invalidCharacter).malformedKind())
+        assertThat(malformedKind { Iban(invalidCharacter) })
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
     }
 
     @Test
-    fun `Parse should reject unknown country code`() {
-        val failure = Iban.parse("UU345678345543234").failure()
+    fun `Invoke should reject unknown country code`() {
+        val failure =
+            assertFailsWith<IbanParseException.UnknownCountryCode> { Iban("UU345678345543234") }
 
-        assertThat(failure)
-            .isInstanceOf<IbanParseException.UnknownCountryCode>()
-            .prop(IbanParseException.UnknownCountryCode::countryCode)
-            .isEqualTo("UU")
+        assertThat(failure).prop(IbanParseException.UnknownCountryCode::countryCode).isEqualTo("UU")
         assertThat(failure.message).isEqualTo("Unknown country code: UU")
     }
 
     @Test
-    fun `Parse should reject wrong length`() {
+    fun `Invoke should reject wrong length`() {
         val tooLong = VALID_IBAN + "0"
 
-        assertThat(Iban.parse(tooLong).failure())
-            .isInstanceOf<IbanParseException.WrongLength>()
-            .prop(IbanParseException.WrongLength::expectedLength)
-            .isEqualTo(18)
+        val failure = assertFailsWith<IbanParseException.WrongLength> { Iban(tooLong) }
+
+        assertThat(failure).prop(IbanParseException.WrongLength::expectedLength).isEqualTo(18)
     }
 
     @Test
-    fun `Parse should reject checksum failure`() {
-        val failure = Iban.parse(INVALID_IBAN).failure()
+    fun `Invoke should reject checksum failure`() {
+        val failure = assertFailsWith<IbanParseException.WrongChecksum> { Iban(INVALID_IBAN) }
 
-        assertThat(failure)
-            .isInstanceOf<IbanParseException.WrongChecksum>()
-            .prop(IbanParseException.WrongChecksum::input)
-            .isEqualTo(INVALID_IBAN)
+        assertThat(failure).prop(IbanParseException.WrongChecksum::input).isEqualTo(INVALID_IBAN)
         assertThat(failure.message).isEqualTo("Wrong check sum for $INVALID_IBAN")
     }
 
     @Test
-    fun `Parse failure should be an IllegalArgumentException`() {
-        assertThat(Iban.parse(INVALID_IBAN).failure()).isInstanceOf<IllegalArgumentException>()
+    fun `Invoke failure should be an IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> { Iban(INVALID_IBAN) }
     }
 
     @Test
@@ -223,53 +213,52 @@ class IbanTest {
                 countryCode = VALID_IBAN.substring(0, 2),
                 bban = VALID_IBAN.substring(4),
             )
-        assertThat(composed.getOrThrow()).isEqualTo(Iban.parse(VALID_IBAN).getOrThrow())
+        assertThat(composed).isEqualTo(Iban(VALID_IBAN))
     }
 
     @Test
     fun `Compose should handle check digits of ten and higher`() {
         val composed = Iban.compose(countryCode = "BI", bban = "10000100010000332045181")
 
-        assertThat(composed.getOrThrow().plain).isEqualTo("BI4210000100010000332045181")
+        assertThat(composed.plain).isEqualTo("BI4210000100010000332045181")
     }
 
     @Test
     fun `Compose should reject blank country code`() {
-        assertThat(Iban.compose(countryCode = "  ", bban = VALID_IBAN.substring(4)).failure())
-            .isInstanceOf<IbanParseException>()
+        assertFailsWith<IbanParseException> {
+            Iban.compose(countryCode = "  ", bban = VALID_IBAN.substring(4))
+        }
     }
 
     @Test
     fun `Compose should reject malformed country code`() {
         assertThat(
-                Iban.compose(countryCode = "potato", bban = VALID_IBAN.substring(4)).malformedKind()
+                malformedKind {
+                    Iban.compose(countryCode = "potato", bban = VALID_IBAN.substring(4))
+                }
             )
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_STRUCTURE)
     }
 
     @Test
     fun `Compose should reject unknown country code`() {
-        assertThat(Iban.compose(countryCode = "XX", bban = VALID_IBAN.substring(4)).failure())
-            .isInstanceOf<IbanParseException.UnknownCountryCode>()
+        assertFailsWith<IbanParseException.UnknownCountryCode> {
+            Iban.compose(countryCode = "XX", bban = VALID_IBAN.substring(4))
+        }
     }
 
     @Test
     fun `Compose should reject wrong length BBAN`() {
-        assertThat(
-                Iban.compose(
-                        countryCode = VALID_IBAN.substring(0, 2),
-                        bban = VALID_IBAN.substring(5),
-                    )
-                    .failure()
-            )
-            .isInstanceOf<IbanParseException.WrongLength>()
+        assertFailsWith<IbanParseException.WrongLength> {
+            Iban.compose(countryCode = VALID_IBAN.substring(0, 2), bban = VALID_IBAN.substring(5))
+        }
     }
 
     @Test
     fun `Equals contract should be satisfied`() {
-        val x = Iban.parse(VALID_IBAN).getOrThrow()
-        val y = Iban.parse(VALID_IBAN).getOrThrow()
-        val z = Iban.parse(VALID_IBAN).getOrThrow()
+        val x = Iban(VALID_IBAN)
+        val y = Iban(VALID_IBAN)
+        val z = Iban(VALID_IBAN)
 
         assertThat(x, "An object is not equal to nul").isNotEqualTo(null)
         assertThat(x, "An object equals itself").isEqualTo(x)
@@ -280,7 +269,7 @@ class IbanTest {
     }
 
     @Test
-    fun `To pretty should format IBAN correctly`() {
+    fun `Add spaces should format IBAN correctly`() {
         tableOf("input", "formatted")
             .row("", "")
             .row("12", "12")
@@ -293,7 +282,9 @@ class IbanTest {
             .row("1234 5678", "1234 5678")
             .row("123456789", "1234 5678 9")
             .row("1234 5678 9", "1234 5678 9")
-            .forAll { input, formatted -> assertThat(Iban.toPretty(input)).isEqualTo(formatted) }
+            .forAll { input, formatted ->
+                assertThat(Iban.addSpaces(Iban.toPlain(input))).isEqualTo(formatted)
+            }
     }
 
     @Test
@@ -317,28 +308,58 @@ class IbanTest {
     fun `Lexical sort should order IBANs correctly`() {
         val expected =
             listOf(
-                Iban.parse("DK3400000000000003").getOrThrow(),
-                Iban.parse("NL41BANK0000000002").getOrThrow(),
-                Iban.parse("NL68BANK0000000001").getOrThrow(),
+                Iban("DK3400000000000003"),
+                Iban("NL41BANK0000000002"),
+                Iban("NL68BANK0000000001"),
             )
         val actual =
             listOf(
-                Iban.parse("NL68BANK0000000001").getOrThrow(),
-                Iban.parse("DK3400000000000003").getOrThrow(),
-                Iban.parse("NL41BANK0000000002").getOrThrow(),
+                Iban("NL68BANK0000000001"),
+                Iban("DK3400000000000003"),
+                Iban("NL41BANK0000000002"),
             )
 
         assertThat(actual.sorted()).isEqualTo(expected)
+    }
+
+    // T3: for a representative set of invalid inputs across every rejection kind, invoke,
+    // toIban and compose must only ever throw IbanParseException — nothing raw from Modulo97 or
+    // the stdlib may escape. This is what makes @Throws sound on Kotlin/Native.
+    @Test
+    fun `Only IbanParseException escapes invoke and toIban for every rejection kind`() {
+        listOf(
+                "",
+                "Shenanigans!",
+                " $VALID_IBAN",
+                "$VALID_IBAN ",
+                "NL03",
+                "NLAB0143267469",
+                VALID_IBAN.replaceRange(6, 7, "_"),
+                "UU345678345543234",
+                VALID_IBAN + "0",
+                INVALID_IBAN,
+            )
+            .forEach { input ->
+                assertFailsWith<IbanParseException>("invoke($input)") { Iban(input) }
+                assertFailsWith<IbanParseException>("toIban($input)") { input.toIban() }
+            }
+    }
+
+    @Test
+    fun `Only IbanParseException escapes compose for every rejection kind`() {
+        assertFailsWith<IbanParseException> { Iban.compose("  ", VALID_IBAN.substring(4)) }
+        assertFailsWith<IbanParseException> { Iban.compose("potato", VALID_IBAN.substring(4)) }
+        assertFailsWith<IbanParseException> { Iban.compose("XX", VALID_IBAN.substring(4)) }
+        assertFailsWith<IbanParseException> {
+            Iban.compose(VALID_IBAN.substring(0, 2), VALID_IBAN.substring(5))
+        }
     }
 
     companion object {
         internal const val VALID_IBAN = "NL03ABNA0143267469"
         private const val INVALID_IBAN = "NL13ABNA0143267469"
 
-        private fun Result<Iban>.failure(): Throwable =
-            exceptionOrNull() ?: fail("Expected a failure, but was $this")
-
-        private fun Result<Iban>.malformedKind(): IbanParseException.Malformed.Kind? =
-            (exceptionOrNull() as? IbanParseException.Malformed)?.kind
+        private fun malformedKind(block: () -> Unit): IbanParseException.Malformed.Kind? =
+            (assertFailsWith<IbanParseException> { block() } as? IbanParseException.Malformed)?.kind
     }
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -19,15 +19,17 @@ Objective-C interop — the path consumers of the published `Kiban.xcframework` 
 Needs a macOS host with Xcode; see `.github/workflows/ios-interop-verify.yml` for on-demand
 CI access to one.
 
-Two things to know before reading it, both findings of the #9 interop review
-([`docs/9-swift-interop-review.md`](../docs/9-swift-interop-review.md)):
+One thing to know before reading it, a finding of the #9 interop review
+([`docs/9-swift-interop-review.md`](../docs/9-swift-interop-review.md)): top-level Kotlin
+extension functions (`toIbanOrNull`, `isValidIban`, `toIban`) surface as static methods on an
+`IbanKt` facade class, not as Swift extensions on `String`.
 
-- Top-level Kotlin extension functions (`toIbanOrNull`, `isValidIban`) surface as static
-  methods on an `IbanKt` facade class, not as Swift extensions on `String`.
-- `Result<Iban>`-returning APIs (`Iban.parse`, `Iban.compose`) erase to an opaque `Any?` with
-  no typed access to the failure, so the sample sticks to `toIbanOrNull`/`isValidIban`. The
-  probe executables that established this live on the `swift-export-playground` branch,
-  alongside the Swift Export experiment.
+`Iban.parse`/`Iban.compose` used to erase to an opaque `Result<Iban>` under Objective-C interop
+(#9's headline finding, since fixed in 0.5.0 — see `docs/9-swift-interop-review.md` for what the
+old shape looked like from Swift). The throwing entry points are now annotated
+`@Throws(IbanParseException::class)`, so the sample also demonstrates catching a failure as a
+Swift error. The probe executables from the original #9 investigation live on the
+`swift-export-playground` branch, alongside the Swift Export experiment.
 
 ```shell
 ./gradlew :library:assembleKibanDebugXCFramework

--- a/samples/jvm-cli/src/main/kotlin/nl/bijdorpstudio/kiban/samples/jvmcli/Main.kt
+++ b/samples/jvm-cli/src/main/kotlin/nl/bijdorpstudio/kiban/samples/jvmcli/Main.kt
@@ -9,34 +9,34 @@ import nl.bijdorpstudio.kiban.toIban
 import nl.bijdorpstudio.kiban.toIbanOrNull
 
 fun main() {
-    // Parse returns Result<Iban>.
-    val iban: Iban = Iban.parse("NL91ABNA0417164300").getOrThrow()
-    println("parse: $iban")
+    // The primary entry point. Throws IbanParseException on invalid input.
+    val iban: Iban = Iban("NL91ABNA0417164300")
+    println("invoke: $iban")
 
-    // Handle failure without exceptions.
-    Iban.parse("not an iban")
-        .fold(
-            onSuccess = { println("fold success: $it") },
-            onFailure = { println("fold failure: ${it.message}") },
-        )
-
-    // Or use the String extensions.
-    val parsed: Result<Iban> = "NL91ABNA0417164300".toIban()
+    // Or use the String extension; same throwing behaviour.
+    val parsed: Iban = "NL91ABNA0417164300".toIban()
     println("toIban: $parsed")
+
+    // Exception-free fast paths.
     val orNull: Iban? = "NL91ABNA0417164301".toIbanOrNull() // null, check digits are wrong
     println("toIbanOrNull (wrong check digits): $orNull")
     val isValid: Boolean = "NL91ABNA0417164300".isValidIban() // true
     println("isValidIban: $isValid")
 
     // Failures carry a typed reason, so you never have to match on messages.
-    when (val failure = Iban.parse("not an iban").exceptionOrNull()) {
-        is IbanParseException.UnknownCountryCode ->
-            println("unknown country: ${failure.countryCode}")
-        is IbanParseException.WrongLength ->
-            println("wrong length: expected ${failure.expectedLength}, got ${failure.actualLength}")
-        is IbanParseException.WrongChecksum -> println("wrong checksum")
-        is IbanParseException.Malformed -> println("malformed: ${failure.kind}")
-        null -> println("parsed successfully")
+    try {
+        Iban("not an iban")
+    } catch (failure: IbanParseException) {
+        when (failure) {
+            is IbanParseException.UnknownCountryCode ->
+                println("unknown country: ${failure.countryCode}")
+            is IbanParseException.WrongLength ->
+                println(
+                    "wrong length: expected ${failure.expectedLength}, got ${failure.actualLength}"
+                )
+            is IbanParseException.WrongChecksum -> println("wrong checksum")
+            is IbanParseException.Malformed -> println("malformed: ${failure.kind}")
+        }
     }
 
     // toString() emits standard formatting, plain is compact.
@@ -44,7 +44,7 @@ fun main() {
     println("plain: ${iban.plain}")
 
     // Input may be formatted.
-    val anotherIban = Iban.parse("BE68 5390 0754 7034").getOrThrow()
+    val anotherIban = Iban("BE68 5390 0754 7034")
     println("parsed formatted input: $anotherIban")
 
     // Iban implements Comparable<T>.
@@ -61,17 +61,16 @@ fun main() {
     val valid = Modulo97.verifyCheckDigits(candidate) // true
     println("verifyCheckDigits: $valid")
 
-    // Compose the IBAN for a country and BBAN; this also returns a Result.
-    val composed =
-        Iban.compose("BI", "10000100010000332045181").getOrThrow() // BI4210000100010000332045181
+    // Compose the IBAN for a country and BBAN; also throws on invalid input.
+    val composed = Iban.compose("BI", "10000100010000332045181") // BI4210000100010000332045181
     println("compose: ${composed.plain}")
 
     // You can query whether an IBAN is of a SEPA-participating country
-    val isSepa = Iban.parse(candidate).getOrThrow().isSEPA // true
+    val isSepa = Iban(candidate).isSEPA // true
     println("isSEPA: $isSepa")
 
     // You can query whether an IBAN is in the SWIFT Registry
-    val isRegistered = Iban.parse(candidate).getOrThrow().isInSwiftRegistry // true
+    val isRegistered = Iban(candidate).isInSwiftRegistry // true
     println("isInSwiftRegistry: $isRegistered")
 
     // Modulo97 API methods take CharSequence, not just String.

--- a/samples/swift-console/Sources/SwiftConsole/main.swift
+++ b/samples/swift-console/Sources/SwiftConsole/main.swift
@@ -1,9 +1,8 @@
 import Kiban
 
-// Top-level Kotlin extension functions (toIbanOrNull, isValidIban) are exported as static
-// methods on an `IbanKt` facade class, not as Swift extensions on String — so the call is
-// `IbanKt.toIbanOrNull("x")`, not `"x".toIbanOrNull()`. For everything else this interop
-// path can and cannot express (notably Result<Iban>), see docs/9-swift-interop-review.md.
+// Top-level Kotlin extension functions (toIbanOrNull, isValidIban, toIban) are exported as
+// static methods on an `IbanKt` facade class, not as Swift extensions on String — so the call is
+// `IbanKt.toIbanOrNull("x")`, not `"x".toIbanOrNull()`. See docs/9-swift-interop-review.md.
 
 guard let iban = IbanKt.toIbanOrNull("NL91ABNA0417164300") else {
     fatalError("expected a valid IBAN")
@@ -17,9 +16,16 @@ print("toIbanOrNull (wrong check digits): \(String(describing: orNull))")
 
 print("isValidIban: \(IbanKt.isValidIban(iban.plain))")
 
-// Result<Iban> (Iban.parse, Iban.compose) is erased to an opaque Any? on this interop path,
-// with no typed access to the failure — that's #9's headline finding, and why those APIs are
-// not demonstrated here. Use toIbanOrNull/isValidIban from Swift instead.
+// 0.5.0 made parsing strict again: Iban(input), Iban.compose(...) and toIban() throw
+// IbanParseException instead of returning Result<Iban> (#9's headline finding about the 0.4.0
+// API), and are annotated @Throws(IbanParseException::class) so this Objective-C interop path
+// surfaces the failure as a catchable Swift error instead of aborting the process.
+do {
+    let unexpected = try IbanKt.toIban("not an iban")
+    print("unexpected success: \(unexpected.plain)")
+} catch {
+    print("toIban(not an iban) failed as expected: \(error)")
+}
 
 print("formatted: \(iban.description)")
 print("plain: \(iban.plain)")


### PR DESCRIPTION
## Summary

Implements the approved design in #100: reverts parsing from the `Result`-returning 0.4.0 shape
back to strict and throwing, and removes every member that was `@Deprecated`.

- **D1/D2/D3** — `Iban(input)` (the `invoke` operator), `Iban.compose(cc, bban)` and
  `String.toIban()` now return `Iban` directly and throw a sealed `IbanParseException` instead of
  returning `Result<Iban>`. All three are annotated `@Throws(IbanParseException::class)`.
  `Iban.parse` and `Iban.valueOf` are removed (`invoke`/`toIban` were the only spellings kept).
- **D4** — `Iban.format`/`Iban.toPretty` are deleted (zero real callers); `Iban.toPlain` and
  `addSpaces` become `internal` (still covered by the existing grouping tests, since `commonTest`
  is a friend module).
- **D5** — removes every other `@Deprecated` member: `Iban.toPlainString()`,
  `CountryCodes.getBankIdentifier(Iban)`, `CountryCodes.getBranchIdentifier(Iban)`,
  `CountryCodes.getLengthForCountryCode(cc)`, `CountryCodes.lastUpdateDateString`.
- **D6** — `CountryCodes.getBankIdentifierInternal`/`getBranchIdentifierInternal` lose the now-
  redundant `Internal` suffix (`internal fun getBankIdentifier`/`getBranchIdentifier`).
- **D7** — closes the silent-construction footgun: `Iban`'s constructor is now `private`
  (was `internal`), with a new `internal fun ofValidated(plain: String): Iban` factory for the
  one caller outside the class body (`toIbanOrNull`/`toIban`) that needs to skip re-validation.
- **D8** (`CountryCodesData` `public` modifier cleanup) — **not done**, see Verification below.

## Why

0.4.0's `Result<Iban>` shape doesn't survive the trip to Swift: the #9 interop review
(`docs/9-swift-interop-review.md`) found it erases to an opaque, unrecoverable `Any?` under
Kotlin/Native's Objective-C interop. 0.5.0 is still unreleased, so this corrects the experiment
before a second published version carries it forward, rather than layering a new breaking change
on top.

## Also updated

- Tests: `IbanTest.kt` and friends rewritten from `Result` assertions to `assertFailsWith`/direct
  value assertions (T1), plus two new tests for T3 (every rejection kind only ever throws
  `IbanParseException` — nothing raw escapes `invoke`, `compose` or `toIban`). T2 (the
  `ofValidated`-not-`Iban(...)` fast-path invariant) is covered by a code comment on the two call
  sites rather than a runtime test, since call counts aren't directly observable — per the issue's
  own note on this.
- `README.md` "Use" section and design-notes bullet, `MIGRATION.md` (added a 0.4.0→0.5.0 section,
  updated the rest of the doc's tables to reflect the current API), `CHANGELOG.md`.
- `samples/jvm-cli` (drops `.getOrThrow()`), `samples/swift-console` (demonstrates the new
  `@Throws` shape via `IbanKt.toIban(...)` in a `do`/`catch`), `samples/README.md`.
- `library/api/jvm/library.api` and `library/api/library.klib.api` (binary-compatibility-validator
  dumps), see Verification.

## Verification

- `./gradlew jvmTest` — **passes**.
- `./gradlew ktfmtCheck` — **passes** (ran `ktfmtFormat` once to apply house style to the new
  code).
- `./gradlew apiCheck` — could not run directly in this sandbox: `library/build.gradle.kts`
  unconditionally applies the Android Kotlin Multiplatform library plugin, which needs
  `dl.google.com`, blocked by this sandbox's egress policy (see `CLAUDE.md`). Used the documented
  workaround (temporarily drop the Android target, run `jvmApiCheck`/`jvmApiDump`, revert before
  committing) to get a real, compiler-verified JVM api dump, which is what's committed at
  `library/api/jvm/library.api`.
- `library/api/library.klib.api` (the merged klib dump covering JS/Wasm/Native/Apple targets) is
  **hand-edited, not verified by an actual `apiDump` run**. Generating it for real needs the
  Kotlin/Native compiler distribution (`download.jetbrains.com`), which this sandbox's egress
  policy also blocks. The edits mirror the JVM dump's verified diff 1:1 (removed declarations,
  `Result<Iban>` → `Iban` on `invoke`/`compose`/`toIban`) — safe to do mechanically because
  Kotlin's klib declaration IDs are computed from name + parameter types, not return type, so
  removing `Result` doesn't change any ID, only the rendered type after `:`. Every `commonMain`
  declaration in this library is target-independent (no `expect`/`actual`), so the JVM-verified
  shape is the correct shape for every other target too. Still, this file should be treated as
  unverified until CI's full-matrix `apiCheck` (`gradle.yml`) runs on this PR.
- **D8 (`CountryCodesData` `public` modifier cleanup) was skipped.** `scripts/generate_country_data.main.kts`
  needs both network access (its `@file:DependsOn` Gradle-script dependencies, `kotlin-csv-jvm`
  and `kotlinpoet-jvm`) and a manually-downloaded SWIFT IBAN Registry TXT file that the script's
  own header says must never be committed to the repo — neither is available in this sandbox. Per
  the issue's own note, this is cosmetic (the enclosing `internal object` already keeps
  `CountryCodesData` out of the public API surface; the `public` modifiers on its members are
  redundant noise, not a functional or API change), so I left it for a maintainer or a future run
  with real registry access rather than guess at codegen output I can't verify.
- **Swift ergonomics: verified for real**, per the issue's explicit ask. I triggered
  `ios-interop-verify.yml` on this branch (run [31333667004](https://github.com/BijdorpStudio/kiban/actions/runs/31333667004),
  succeeded) — it built the real `Kiban.xcframework` and ran `samples/swift-console` against it.
  Confirmed, recorded in `docs/9-swift-interop-review.md`:
  - The generated Objective-C header shows `invoke(input:)`, `compose(countryCode:bban:)` and
    `IbanKt.toIban(...)` all carry an `NSError**` out-param, each with Kotlin/Native's own doc
    comment: *"This method converts instances of IbanParseException to errors. Other uncaught
    Kotlin exceptions are fatal."*
  - Calling `IbanKt.toIban("not an iban")` from Swift's `do { try ... } catch { ... }` **does not
    crash the process** (unlike the old unannotated `valueOf`, which #9 confirmed SIGABRTs) — the
    caught error prints as `Error Domain=KotlinException ... UserInfo={..., KotlinException=nl.bijdorpstudio.kiban.IbanParseException.Malformed: Characters at index 2 and 3 not both numeric. notaniban, ...}`.
  - **Still open**: whether `error.userInfo["KotlinException"]` can be `as?`-downcast to the real
    `IbanParseException.Malformed` type from Swift, vs. only reading its string description — not
    exercised by this run, and the concrete next thing to check before treating the #9 companion-
    surface question as fully settled.
  - `Iban`'s companion `invoke`/`compose` are not surfaced as Swift initializers under this path —
    they're `Iban.companion.invoke(input:)`/`Iban.companion.compose(...)` — which is why the
    sample demonstrates the throwing path via `IbanKt.toIban(...)` instead.

Closes #100
