### PR TITLE
Open the 0.6.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version History
 
-## 0.5.0 (unreleased)
+## 0.6.0 (unreleased)
+
+## 0.5.0
 
 **Breaking changes**
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 group = "nl.bijdorpstudio.kiban"
 
-version = "0.5.0"
+version = "0.6.0"
 
 ktfmt { kotlinLangStyle() }
 


### PR DESCRIPTION
Fixes #105.

## Changes

| File | Change |
| --- | --- |
| `library/build.gradle.kts` | `version = "0.5.0"` → `"0.6.0"` |
| `CHANGELOG.md` | drop `(unreleased)` from the 0.5.0 heading; add an empty `## 0.6.0 (unreleased)` section |

## What deliberately did *not* change

`grep -rn "0\.5\.0"` turns up six more hits. None of them should move:

- **`README.md:36,46`** — the install snippets. Per [`3a8262a`](https://github.com/BijdorpStudio/kiban/commit/3a8262a94478df4e14f9223cc04b9617c6b63309) ("Open the 0.5.0 development cycle"), these state the latest *released* version, not what `main` builds toward. Bumping them here would point users at an artifact that does not exist.
- **`MIGRATION.md:10,14,15`** — the "Upgrading from 0.4.0 to 0.5.0" section is a historical record.
- **`docs/9-swift-interop-review.md`**, **`samples/README.md`**, **`samples/swift-console/Sources/SwiftConsole/main.swift`** — prose describing what changed in 0.5.0.

`library/api/` dumps carry no version string, so `apiCheck` is unaffected.

## Verification

No local Gradle run — the change is a version literal plus a Markdown heading, and CI runs the full target matrix across Linux and macOS on this PR. Relying on that.

## Note, unrelated to this PR

0.5.0 is tagged and the `publish` job succeeded, but it is **not on Maven Central yet**: `maven-metadata.xml` still reports `<release>0.4.0</release>` and `.../kiban/0.5.0/` 404s. `library/build.gradle.kts` calls `publishToMavenCentral()` with no arguments, which on vanniktech 0.37.0 leaves `automaticRelease = false`, so the deployment is waiting on a manual **Publish** in the Central Portal. Worth doing before the README badge is resolvable.