### PR TITLE
Make the SWIFT registry sync able to run unattended

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -10,10 +10,19 @@
 # the job workspace under scripts/input/ (gitignored), and the pull request carries just the
 # derived artifacts: CountryCodesData.kt and the country test data table.
 #
+# The registry's release number is not published anywhere a machine can read: the download sends
+# no Content-Disposition filename and the page states no release. So this job never asks for one
+# up front. It regenerates the data using the revision and datestamp already committed - metadata
+# the generator only stamps into its output - and diffs. Unchanged (the outcome of all but a
+# couple of runs a year) means the job is done without a revision ever being needed. Changed means a
+# maintainer re-runs it with the 'rev' input, which is worth the interruption exactly then.
+#
 # Best-effort by design: headless Chromium may get flagged even where headed browsing works, so
 # a failed headless attempt is retried headed under Xvfb, and a failure of both only costs the
 # convenience - manually downloading the TXT into scripts/input/ and running the generator stays
-# the guaranteed fallback. The schedule is monthly because the registry changes ~1-2x/year.
+# the guaranteed fallback. The schedule is weekly: the registry only changes ~1-2x/year, but a run
+# that finds nothing costs a couple of minutes and stops silently, and checking often shortens the
+# window in which a bot-detection change goes unnoticed.
 #
 # Two repository settings this job depends on: Actions must be allowed to create pull requests
 # (Settings > Actions > General), and note that pull requests opened with GITHUB_TOKEN do not
@@ -25,11 +34,11 @@ name: SWIFT registry sync
 
 on:
   schedule:
-    - cron: '17 4 1 * *'
+    - cron: '17 4 * * 1'
   workflow_dispatch:
     inputs:
       rev:
-        description: 'Registry revision to record, e.g. 103 (only needed when detection fails)'
+        description: 'Registry revision to record, e.g. 103 (needed only once the registry data has changed)'
         required: false
         type: string
 
@@ -75,34 +84,50 @@ jobs:
         if: steps.headless.outcome == 'failure'
         run: xvfb-run -a kotlin scripts/fetch_registry.main.kts --out "$REGISTRY_TXT_PATH" --headed ${REV:+--rev "$REV"}
 
-      # Regenerated with the currently committed datestamp first: LAST_UPDATE_DATE would
-      # otherwise differ on every run and turn "nothing changed" into a monthly no-op PR.
-      - name: Regenerate the country data at the committed datestamp
+      # Regenerated with the currently committed revision and datestamp first. Both are metadata
+      # the generator only stamps into the output: reusing the committed values keeps a run where
+      # the registry did not change byte-identical to HEAD, so "nothing changed" cannot turn into
+      # a weekly no-op PR. It also means this step needs no revision of its own - which matters,
+      # because there is usually none to be had (see scripts/fetch_registry.main.kts).
+      # ktfmt is not optional here: KotlinPoet's raw output differs from the committed files in
+      # whitespace alone (license header indent, comment wrapping), so an unformatted regeneration
+      # reports ~1700 changed lines even when every byte of registry data is identical.
+      - name: Regenerate the country data as currently committed
         run: |
-          if [ -z "${REGISTRY_REV:-}" ]; then
-            echo "::error::Could not detect the registry revision; re-run this workflow with the 'rev' input."
-            exit 1
-          fi
           previous_date="$(sed -n 's/.*LAST_UPDATE_DATE: String = "\(.*\)"$/\1/p' "$DATA_FILE")"
+          previous_rev="$(sed -n 's/.*LAST_UPDATE_REV: String = "\(.*\)"$/\1/p' "$DATA_FILE")"
           kotlin scripts/generate_country_data.main.kts \
-            --registry "$REGISTRY_TXT_PATH" --rev "$REGISTRY_REV" --date "$previous_date"
+            --registry "$REGISTRY_TXT_PATH" --rev "$previous_rev" --date "$previous_date"
+          ./gradlew --quiet :library:ktfmtFormatKmpCommonMain :library:ktfmtFormatKmpCommonTest
 
       - name: Check whether the generated data changed
         id: diff
         run: |
           if git diff --quiet -- "$DATA_FILE" "$TEST_DATA_FILE"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Country data is already up to date with registry rev ${REGISTRY_REV}."
+            echo "Country data is already up to date with the registry as last modified ${REGISTRY_LAST_MODIFIED:-unknown} (sha256 ${REGISTRY_SHA256})."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
             git --no-pager diff --stat -- "$DATA_FILE" "$TEST_DATA_FILE"
           fi
 
-      - name: Restamp the regenerated data with today's date
+      # Only reached when the registry actually changed - the one case where the release number
+      # has to be real, and the one case where asking a human for it is worth the interruption.
+      - name: Require a registry revision for the changed data
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          if [ -z "${REGISTRY_REV:-}" ]; then
+            echo "::error::The registry TXT changed (sha256 ${REGISTRY_SHA256}, last modified ${REGISTRY_LAST_MODIFIED:-unknown}), but its release number is not stated anywhere machine-readable. Look it up on https://www.swift.com/standards/data-standards/iban and re-run this workflow with the 'rev' input."
+            exit 1
+          fi
+          echo "Registry changed; recording revision ${REGISTRY_REV}."
+
+      - name: Restamp the regenerated data with today's date and revision
         if: steps.diff.outputs.changed == 'true'
         run: |
           kotlin scripts/generate_country_data.main.kts \
             --registry "$REGISTRY_TXT_PATH" --rev "$REGISTRY_REV"
+          ./gradlew --quiet :library:ktfmtFormatKmpCommonMain :library:ktfmtFormatKmpCommonTest
 
       - name: Verify the regenerated data
         if: steps.diff.outputs.changed == 'true'
@@ -129,6 +154,7 @@ jobs:
             "Generated by the [SWIFT registry sync workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)." \
             "" \
             "- Registry revision: \`$REGISTRY_REV\`" \
+            "- Registry TXT last modified: \`${REGISTRY_LAST_MODIFIED:-unknown}\`" \
             "- Registry TXT sha256: \`$REGISTRY_SHA256\`" \
             "" \
             "The registry TXT itself is not committed (it is not redistributable); only the files" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 0.6.0 (unreleased)
 
+**Infrastructure**
+
+* Made the SWIFT registry sync (#53) able to run unattended. It regenerates and diffs the country data
+  before asking for a registry revision, so the ~50 runs a year that find nothing finish silently and only
+  a real registry change interrupts a maintainer — the release number is not published anywhere
+  machine-readable, so it has to be supplied by hand when it matters. The generated sources are now
+  formatted with ktfmt before diffing, without which every run reported ~1,700 whitespace-only changed
+  lines and would have opened a no-op pull request. The schedule moved from monthly to weekly.
+* `scripts/fetch_registry.main.kts` now reports a blocked download with the manual/`--headed` fallback
+  advice instead of a raw Playwright stack trace: the block happens below the HTTP layer during
+  navigation, so the existing response validation never saw it. It also exports the registry TXT's
+  `last-modified` date for the sync workflow's logs and pull request body.
+
 ## 0.5.0
 
 **Breaking changes**

--- a/README.md
+++ b/README.md
@@ -169,16 +169,22 @@ Adopted design choices from the Java library, plus:
 
 The embedded country data (`CountryCodesData.kt`) and the country test data table are generated from the SWIFT IBAN Registry TXT. The registry TXT is not redistributable and is never committed: it lives only in the gitignored `scripts/input/`.
 
-* **Automatically:** the [SWIFT registry sync](.github/workflows/registry-sync.yml) workflow runs monthly (and on demand), downloads the registry through a real Chromium context, regenerates the data, and opens a pull request when it changed. Bot detection is outside this project's control, so treat it as convenience rather than a guarantee.
+* **Automatically:** the [SWIFT registry sync](.github/workflows/registry-sync.yml) workflow runs weekly (and on demand), downloads the registry through a real Chromium context, regenerates the data, and opens a pull request when it changed. Bot detection is outside this project's control, so treat it as convenience rather than a guarantee.
 * **Manually,** which always works and is the fallback when the workflow is blocked:
 
 ```shell
 # Download "IBAN Registry (TXT)" in a browser from https://www.swift.com/standards/data-standards/iban,
-# or try the scripted download:
+# or try the scripted download (add --headed if headless Chromium is blocked on your network):
 kotlin scripts/fetch_registry.main.kts --out scripts/input/iban-registry.txt
 
 kotlin scripts/generate_country_data.main.kts --registry scripts/input/iban-registry.txt --rev <revision>
+
+# The generator emits unformatted KotlinPoet output; without this the diff is thousands of
+# whitespace-only lines:
+./gradlew :library:ktfmtFormatKmpCommonMain :library:ktfmtFormatKmpCommonTest
 ```
+
+The registry's release number has to be supplied by hand: the download endpoint sends no filename and the registry page states no release, so neither script can detect it. Read it off the [registry PDF](https://www.swift.com/swift-resource/9606/download) and pass it as `--rev`.
 
 The generator validates every entry before writing (mod-97 checksum, declared length and country prefix, and bank/branch identifier positions cross-checked against the registry's own identifier examples), so a malformed or truncated download fails loudly instead of landing in the library.
 

--- a/scripts/fetch_registry.main.kts
+++ b/scripts/fetch_registry.main.kts
@@ -2,10 +2,13 @@
 /*
  * Downloads the SWIFT IBAN Registry TXT through a real browser engine.
  *
- * The download endpoint blocks plain HTTP clients below the HTTP layer: the TLS handshake is
- * dropped on fingerprint, so no shell script or HTTP library ever sees a status code. A real
- * Chromium context that has actually loaded the registry page can fetch it: a programmatic
- * fetch() from page context returns the TXT with HTTP 200.
+ * Swift blocks unrecognised clients below the HTTP layer, so no shell script or HTTP library ever
+ * sees a status code - the connection just hangs and is eventually reset. This covers the
+ * registry page itself, not only the download endpoint, which is why failures surface as
+ * navigation timeouts rather than as a bot-check page. A real Chromium context that has actually
+ * loaded the page can fetch it: a programmatic fetch() from page context returns the TXT with
+ * HTTP 200. Headless Chromium is itself blocked from some networks even where headed works, so
+ * --headed is a genuine fallback and not just a debugging aid.
  *
  * The downloaded TXT is NOT redistributable and must never be committed. The default output
  * path lives under scripts/input/, which is gitignored; only the artifacts generated from it
@@ -18,8 +21,13 @@
  * and then feed the result to the generator:
  *     kotlin scripts/generate_country_data.main.kts --registry scripts/input/iban-registry.txt --rev <NN>
  *
- * --rev overrides the revision this script detects from the download's filename or the page
- * text; --self-check runs the offline assertions over the parsing helpers and exits.
+ * --rev records the registry revision; --self-check runs the offline assertions over the parsing
+ * helpers and exits. The revision cannot currently be detected: the download endpoint sends no
+ * Content-Disposition header at all, and the registry page names no release number anywhere. The
+ * detection below is therefore best-effort against a page that may start stating one again, and
+ * an unknown revision is the normal outcome rather than a failure - it only has to be resolved
+ * once the registry TXT has actually changed, which is why registry-sync.yml regenerates and
+ * diffs first and demands a revision second.
  *
  * Bot detection is an arms race this project does not control, so treat the automated path as
  * best-effort convenience: downloading the TXT manually in a browser into scripts/input/ and
@@ -27,7 +35,8 @@
  * convenience if this stops working.
  *
  * Inside GitHub Actions (when $GITHUB_ENV is set) the script exports REGISTRY_TXT,
- * REGISTRY_SHA256 and REGISTRY_REV for the steps that follow.
+ * REGISTRY_SHA256, REGISTRY_LAST_MODIFIED and - when known - REGISTRY_REV for the steps that
+ * follow.
  */
 
 @file:DependsOn("com.microsoft.playwright:playwright:1.62.0")
@@ -45,6 +54,12 @@ val registryMarker = "IBAN prefix country code (ISO 3166)"
 
 /** The registry TXT is ~34 KB; anything much smaller is not the registry. */
 val minimumRegistrySize = 10_000
+
+/** How to get the registry by hand; every acquisition failure ends with this. */
+val fallbackAdvice =
+    "Bot detection may have caught this run. Retry with --headed (under xvfb on a headless " +
+        "host), or download the TXT manually in a browser from $registryPage and pass it to " +
+        "scripts/generate_country_data.main.kts."
 
 // ---------------------------------------------------------------------------
 // Parsing helpers (pure; covered by --self-check)
@@ -87,6 +102,34 @@ fun problemsWith(status: Int, contentType: String, text: String): List<String> =
     }
 }
 
+/**
+ * Condenses a Playwright failure into the one line that says what went wrong: it reports errors
+ * as a multi-line `Error { ... }` dump whose first line carries no information.
+ */
+fun summarize(message: String?): String {
+    val lines = message?.lines()?.map { it.trim() }?.filter { it.isNotEmpty() }.orEmpty()
+    val stated = lines.firstOrNull { it.startsWith("message='") }?.removePrefix("message='")?.trim()
+    return stated?.takeIf { it.isNotEmpty() } ?: lines.firstOrNull() ?: "no details"
+}
+
+/**
+ * The `KEY=value` block the workflow steps read back out of `$GITHUB_ENV`. Unknown values are
+ * omitted rather than exported empty, so the workflow can test for their presence.
+ */
+fun githubEnvExports(path: String, digest: String, lastModified: String?, rev: String?): String =
+    buildString {
+        appendLine("REGISTRY_TXT=$path")
+        appendLine("REGISTRY_SHA256=$digest")
+        if (!lastModified.isNullOrEmpty()) appendLine("REGISTRY_LAST_MODIFIED=$lastModified")
+        if (rev != null) appendLine("REGISTRY_REV=$rev")
+    }
+
+/** Runs [step], turning a failure into an error that says what broke and how to work around it. */
+fun <T> attempting(what: String, step: () -> T): T =
+    runCatching(step).getOrElse {
+        error("Could not $what: ${summarize(it.message)}\n\n$fallbackAdvice")
+    }
+
 fun sha256(text: String): String =
     MessageDigest.getInstance("SHA-256").digest(text.toByteArray()).joinToString("") {
         "%02x".format(it)
@@ -124,6 +167,7 @@ val fetchInPageContext =
             status: response.status,
             contentType: response.headers.get('content-type') || '',
             disposition: response.headers.get('content-disposition') || '',
+            lastModified: response.headers.get('last-modified') || '',
             text: text,
         }
     }
@@ -134,6 +178,7 @@ data class RegistryDownload(
     val status: Int,
     val contentType: String,
     val disposition: String,
+    val lastModified: String,
     val text: String,
     val pageText: String,
 )
@@ -146,14 +191,20 @@ fun downloadRegistry(): RegistryDownload =
             .use { browser ->
                 val page = browser.newPage()
                 page.setDefaultTimeout(timeoutMillis)
-                page.navigate(registryPage)
+                // Blocked clients are dropped below the HTTP layer, so this hangs until it times
+                // out rather than returning a page that problemsWith() could report on.
+                attempting("load $registryPage") { page.navigate(registryPage) }
 
-                @Suppress("UNCHECKED_CAST")
-                val response = page.evaluate(fetchInPageContext, registryTxt) as Map<String, Any?>
+                val response =
+                    attempting("fetch $registryTxt from the loaded page") {
+                        @Suppress("UNCHECKED_CAST")
+                        page.evaluate(fetchInPageContext, registryTxt) as Map<String, Any?>
+                    }
                 RegistryDownload(
                     status = (response["status"] as Number).toInt(),
                     contentType = response["contentType"] as String,
                     disposition = response["disposition"] as String,
+                    lastModified = response["lastModified"] as String,
                     text = response["text"] as String,
                     pageText = runCatching { page.innerText("body") }.getOrDefault(""),
                 )
@@ -169,9 +220,8 @@ fun fetchRegistry() {
         error(
             "The registry download did not return the registry TXT:\n" +
                 problems.joinToString("\n") { " - $it" } +
-                "\n\nBot detection may have caught this run. Retry with --headed (under xvfb on a " +
-                "headless host), or download the TXT manually in a browser from $registryPage " +
-                "and pass it to scripts/generate_country_data.main.kts."
+                "\n\n" +
+                fallbackAdvice
         )
     }
 
@@ -185,22 +235,21 @@ fun fetchRegistry() {
 
     println("Downloaded ${download.text.length} characters to ${out.path}")
     println("sha256: $digest")
+    if (download.lastModified.isNotEmpty()) println("last-modified: ${download.lastModified}")
     if (rev != null) {
         println("Registry revision: $rev${if (revOverride != null) " (from --rev)" else ""}")
     } else {
         println(
-            "Could not detect the registry revision from the download filename " +
-                "(${filename ?: "none"}) or the page text; pass --rev <NN> explicitly."
+            "Registry revision: unknown, which is the norm - the download states none in a " +
+                "Content-Disposition filename (${filename ?: "no filename"}) and the page names " +
+                "no release. Pass --rev <NN> to record one; it is only needed once the generated " +
+                "data actually changes."
         )
     }
 
     System.getenv("GITHUB_ENV")?.let { githubEnv ->
         File(githubEnv).appendText(
-            buildString {
-                appendLine("REGISTRY_TXT=${out.path}")
-                appendLine("REGISTRY_SHA256=$digest")
-                if (rev != null) appendLine("REGISTRY_REV=$rev")
-            }
+            githubEnvExports(out.path, digest, download.lastModified, rev)
         )
     }
 }
@@ -273,6 +322,52 @@ fun selfCheck() {
         1,
         problemsWith(200, "text/plain", registryMarker + "\tAD\n").size,
     )
+
+    expect(
+        "summary of a Playwright error dump",
+        "Timeout 60000ms exceeded.",
+        summarize("com.microsoft.playwright.TimeoutError: Error {\n  message='Timeout 60000ms exceeded.\n  name='TimeoutError\n}"),
+    )
+    expect(
+        "summary of a single-line failure",
+        "net::ERR_CONNECTION_RESET",
+        summarize("net::ERR_CONNECTION_RESET"),
+    )
+    expect("summary of a failure without a message", "no details", summarize(null))
+    expect("summary of a blank message", "no details", summarize("   \n  "))
+
+    expect(
+        "GitHub env exports with everything known",
+        "REGISTRY_TXT=/w/registry.txt\n" +
+            "REGISTRY_SHA256=abc123\n" +
+            "REGISTRY_LAST_MODIFIED=Thu, 18 Jun 2026 08:36:58 GMT\n" +
+            "REGISTRY_REV=102\n",
+        githubEnvExports("/w/registry.txt", "abc123", "Thu, 18 Jun 2026 08:36:58 GMT", "102"),
+    )
+    // The download endpoint sends no Content-Disposition, so an undetected revision is the norm:
+    // REGISTRY_REV must then be absent rather than empty, or the workflow's -z test would pass.
+    expect(
+        "GitHub env exports without a revision",
+        "REGISTRY_TXT=/w/registry.txt\nREGISTRY_SHA256=abc123\n",
+        githubEnvExports("/w/registry.txt", "abc123", null, null),
+    )
+
+    // A connection reset dies inside page.navigate, before any response exists to validate, so
+    // the acquisition steps have to carry the fallback guidance themselves.
+    val failed =
+        runCatching { attempting("load the registry page") { error("Timeout 60000ms exceeded.") } }
+            .exceptionOrNull()
+    expect(
+        "a failed step says what it was doing",
+        "Could not load the registry page: Timeout 60000ms exceeded.",
+        failed?.message?.lineSequence()?.first(),
+    )
+    expect(
+        "a failed step ends with the manual fallback",
+        true,
+        failed?.message?.contains("download the TXT manually in a browser"),
+    )
+    expect("a successful step returns its value", 42, attempting("count") { 42 })
 
     expect(
         "sha256 of the standard test vector",


### PR DESCRIPTION
Follow-up to #106. I ran the new sync locally on a real macOS host against the live endpoint; three things would have kept it from ever completing a scheduled run.

## The registry revision is not machine-readable, so the job can't ask for it up front

The download endpoint sends **no `Content-Disposition` header at all**, and the registry page names no release number anywhere — I dumped every readable response header and every registry-related line of page text to confirm. Two of the page's other resources do send filenames (`swift_iban_registration_form_2026-1.docx`), just not the two that matter.

So detection always failed, and the workflow demanded a revision in its first generation step. Every scheduled run would have exited 1, and `schedule:` can't supply the `rev` input.

The job now regenerates using the revision and datestamp **already committed** — both are metadata the generator only stamps into its output — and diffs first. Unchanged (all but a couple of runs a year) finishes silently with no revision needed. Changed fails with the sha256, `last-modified` and where to look the release number up, which is worth the interruption exactly then.

## The diff was whitespace, not data

KotlinPoet's raw output differs from the committed files in license-header indentation and comment wrapping, because the committed files have been through ktfmt. Regenerating with byte-identical registry data produced **1,712 changed lines in each file** — a weekly no-op PR, and it would have hidden real changes in the noise.

Both generation steps now run `:library:ktfmtFormatKmpCommonMain :library:ktfmtFormatKmpCommonTest` before the diff. README documents the same step for the manual flow.

## Blocked downloads reported a Playwright stack trace

Swift blocks unrecognised clients below the HTTP layer, and this covers the **registry page itself**, not only the download endpoint — plain `curl` on the page gets 0 bytes in 40s. Navigation hangs and the connection is reset, so the failure lands inside `page.navigate`, before any response exists for `problemsWith()` to validate. The carefully written "retry with `--headed`" guidance was unreachable for the one failure mode that actually happens.

Both acquisition steps now go through `attempting()`, which re-raises with that guidance attached:

```
java.lang.IllegalStateException: Could not load https://www.swift.com/standards/data-standards/iban: Timeout 20000ms exceeded.
Bot detection may have caught this run. Retry with --headed (under xvfb on a headless host), or download the TXT manually in a browser from … and pass it to scripts/generate_country_data.main.kts.
```

## Also

* Schedule moved monthly → weekly. A run that finds nothing costs a couple of minutes and stops silently, and checking often shortens the window in which a bot-detection change goes unnoticed.
* The script exports `REGISTRY_LAST_MODIFIED` (a real header) for the logs and PR body.
* `githubEnvExports()` — the previously inline, untested contract between script and workflow — is extracted and covered, including that an unknown revision must be *absent* rather than empty, or the workflow's `-z` test would silently pass.

## Verification

Run on macOS against the live endpoint, not a sandbox. Each new self-check was watched fail before it was implemented.

| Check | Result |
|---|---|
| `kotlin scripts/fetch_registry.main.kts --self-check` | 30 checks pass (was 21) |
| Headless download, real block | Fails with the fallback guidance, not a Playwright dump |
| `--headed` download | 34,834 chars, sha256 `e6bae047…`, prints `last-modified` |
| `$GITHUB_ENV` exports | `REGISTRY_TXT`, `REGISTRY_SHA256`, `REGISTRY_LAST_MODIFIED`; no `REGISTRY_REV` |
| Unchanged path, end to end | generate + ktfmt + diff → byte-identical to HEAD, `changed=false` |
| Changed path, end to end | `::error::` with sha256 + last-modified, would exit 1 |
| Workflow YAML | parses; 12 steps, conditions correct |
| `./gradlew ktfmtCheck` | exit 0 |

`jvmTest` was not run: no library sources changed (the generated files were reverted to HEAD after the simulations).

**Untested:** whether GitHub's runners get through headless Chromium — their egress IPs differ from mine, and headless is blocked from my network. That is what the existing Xvfb headed retry is for. Worth one manual `workflow_dispatch` run before trusting the schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)