### PR TITLE
Drop the headless download attempt from the registry sync

### DIFF
--- a/.github/workflows/registry-sync.yml
+++ b/.github/workflows/registry-sync.yml
@@ -17,12 +17,12 @@
 # couple of runs a year) means the job is done without a revision ever being needed. Changed means a
 # maintainer re-runs it with the 'rev' input, which is worth the interruption exactly then.
 #
-# Best-effort by design: headless Chromium may get flagged even where headed browsing works, so
-# a failed headless attempt is retried headed under Xvfb, and a failure of both only costs the
-# convenience - manually downloading the TXT into scripts/input/ and running the generator stays
-# the guaranteed fallback. The schedule is weekly: the registry only changes ~1-2x/year, but a run
-# that finds nothing costs a couple of minutes and stops silently, and checking often shortens the
-# window in which a bot-detection change goes unnoticed.
+# Best-effort by design: acquisition runs headed under Xvfb because headless Chromium is blocked
+# (see the download step), and a failure only costs the convenience - manually downloading the TXT
+# into scripts/input/ and running the generator stays the guaranteed fallback. A failed run here
+# now means something actually broke. The schedule is weekly: the registry only changes ~1-2x/year,
+# but a run that finds nothing costs about two minutes and stops silently, and checking often
+# shortens the window in which a bot-detection change goes unnoticed.
 #
 # Two repository settings this job depends on: Actions must be allowed to create pull requests
 # (Settings > Actions > General), and note that pull requests opened with GITHUB_TOKEN do not
@@ -75,13 +75,14 @@ jobs:
       - name: Check the fetch script's parsing helpers
         run: kotlin scripts/fetch_registry.main.kts --self-check
 
-      - name: Download the registry TXT (headless)
-        id: headless
-        continue-on-error: true
-        run: kotlin scripts/fetch_registry.main.kts --out "$REGISTRY_TXT_PATH" ${REV:+--rev "$REV"}
-
+      # Headed under Xvfb, with no headless attempt first. Headless Chromium is dropped by Swift's
+      # edge from a consumer ISP and from GitHub's runner range alike (run 31359092080), which puts
+      # the tell in the client fingerprint - navigator.webdriver, the HeadlessChrome UA token, no
+      # GPU - rather than in the origin IP. So a headless attempt is a guaranteed ~60s of every run
+      # buying a signal nothing acts on: if it ever started working it would save ten seconds of
+      # Xvfb startup. Do not re-add it as an optimisation. The script still defaults to headless,
+      # which is right for anyone whose network is not blocked and for hosts without a display.
       - name: Download the registry TXT (headed, under Xvfb)
-        if: steps.headless.outcome == 'failure'
         run: xvfb-run -a kotlin scripts/fetch_registry.main.kts --out "$REGISTRY_TXT_PATH" --headed ${REV:+--rev "$REV"}
 
       # Regenerated with the currently committed revision and datestamp first. Both are metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   a real registry change interrupts a maintainer — the release number is not published anywhere
   machine-readable, so it has to be supplied by hand when it matters. The generated sources are now
   formatted with ktfmt before diffing, without which every run reported ~1,700 whitespace-only changed
-  lines and would have opened a no-op pull request. The schedule moved from monthly to weekly.
+  lines and would have opened a no-op pull request. The schedule moved from monthly to weekly, and
+  acquisition goes straight to headed Chromium under Xvfb: headless is dropped by Swift's edge from
+  unrelated networks alike, so attempting it first spent ~60s of every run and left a failed step on
+  otherwise green builds. The script itself still defaults to headless.
 * `scripts/fetch_registry.main.kts` now reports a blocked download with the manual/`--headed` fallback
   advice instead of a raw Playwright stack trace: the block happens below the HTTP layer during
   navigation, so the existing response validation never saw it. It also exports the registry TXT's

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ The embedded country data (`CountryCodesData.kt`) and the country test data tabl
 
 ```shell
 # Download "IBAN Registry (TXT)" in a browser from https://www.swift.com/standards/data-standards/iban,
-# or try the scripted download (add --headed if headless Chromium is blocked on your network):
+# or try the scripted download. Headless Chromium is blocked by Swift's bot detection from at least
+# some networks (which is why CI runs headed under Xvfb), so reach for --headed when this times out:
 kotlin scripts/fetch_registry.main.kts --out scripts/input/iban-registry.txt
 
 kotlin scripts/generate_country_data.main.kts --registry scripts/input/iban-registry.txt --rev <revision>


### PR DESCRIPTION
Follow-up to #111. The first real run of the sync ([31359092080](https://github.com/BijdorpStudio/kiban/actions/runs/31359092080)) confirmed headless Chromium is blocked on GitHub's runners too:

```
Loading https://www.swift.com/standards/data-standards/iban in headless Chromium...
java.lang.IllegalStateException: Could not load …: Timeout 60000ms exceeded.
```

The Xvfb headed retry then succeeded, downloading a registry TXT with `sha256 e6bae047…` — byte-identical to what the same script fetches on a Mac, so the headed path is getting the real file and not a bot-check page.

## Why remove rather than keep it as a canary

Blocked from a Dutch consumer ISP and from Azure's GitHub-runner range: two unrelated origins. That puts the tell in the client fingerprint — `navigator.webdriver`, the `HeadlessChrome` UA token, no GPU, no window chrome — not in the IP, so it isn't going to spontaneously start working.

Meanwhile it cost ~60s of the run's ~172s, every week, and left a red `Process completed with exit code 3` annotation on an otherwise green build. The signal it bought has no consumer: if headless ever did start working, the payoff would be ten seconds of Xvfb startup. A canary whose chirp triggers no decision isn't worth a third of the runtime.

Acquisition now goes straight to headed under Xvfb, which also means a failed run in this job means something actually broke.

## What is deliberately unchanged

`scripts/fetch_registry.main.kts` still **defaults to headless** — that is right for anyone whose network isn't blocked, and `--headed` cannot launch at all on a host without a display. Only the workflow skips ahead. The download step carries a comment with the evidence and a "do not re-add this as an optimisation" note, so it doesn't come back in six months.

README now says headless is blocked from at least some networks rather than implying it usually works.

## Verification

- Workflow YAML parses; 11 steps (was 12), no dangling `steps.headless` reference or `continue-on-error`.
- The removed step is the only change to job behaviour — the headed step is unchanged apart from losing its `if:` condition.
- Expected runtime drops from ~2m52s to roughly ~1m50s. That's the one claim here I can't verify before merge, since the sync only runs from `main`; worth a `workflow_dispatch` afterwards to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)