### PR TITLE
Update sandbox notes: network egress restrictions are lifted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,20 +6,24 @@ real limitations that look like build breakage at first glance but aren't.
 Read this before spending time diagnosing a `./gradlew` failure as a code
 regression.
 
-The JVM side works normally: plain `./gradlew jvmTest`, `jvmApiCheck`,
-`ktfmtCheck`, `:samples:jvm-cli:run` and friends run out of the box, with no
-workarounds. (Older revisions of this file documented an egress block on
-`dl.google.com` that broke every `./gradlew` invocation at configuration time
-and required temporarily removing the Android target; that restriction has
-been lifted, and the workaround is gone with it.) The gaps that remain are
-below.
+Network egress is no longer a problem: `./gradlew jvmTest`, the full
+`apiCheck` (both `jvmApiCheck` and `klibApiCheck` — unbuildable Apple targets
+are inferred), `ktfmtCheck`, Kotlin/Native compilation and testing for host
+targets (`compileKotlinLinuxX64`, `linuxX64Test`), and `:samples:jvm-cli:run`
+all run out of the box. (Older revisions of this file documented egress
+blocks on `dl.google.com` and `download.jetbrains.com` that broke AGP
+resolution and the Kotlin/Native toolchain download, with workarounds to
+match; those restrictions have been lifted and the workarounds are gone.)
+The two gaps that remain are about what's installed on the container, not
+the network.
 
 ## No Apple toolchain in most cloud sandboxes
 
 Targets that need Xcode/macOS — `ios*`, `macos*`, `tvos*`, `watchos*` — can't
-be compiled or tested on a Linux container. `apiCheck` builds a klib for
-*every* declared target (see `library/build.gradle.kts`'s target list), so it
-also needs the Apple toolchain and can't fully pass here.
+be compiled or tested on a Linux container, and neither can
+`assembleKibanDebugXCFramework` (used by `samples/swift-console`, see #68).
+`apiCheck` is *not* blocked by this: the klib check infers the Apple targets
+from the buildable ones and passes here.
 
 This also blocks anything that requires actually running Swift-facing code
 (e.g. reviewing how the API surfaces through Objective-C interop or Swift
@@ -34,43 +38,22 @@ also builds and runs `samples/swift-console` (#68) — the concrete testbed
 #9's actual API review needs — so Swift Export artifact generation for that
 sample is the only piece #9 still has to add.
 
-## Kotlin/Native toolchain dependencies can't download
-
-Any task that needs to *compile* a Kotlin/Native target — not just Apple
-ones — still fails here. The compiler distribution itself resolves fine (it
-comes from Maven Central), but the platform toolchain bundles it then fetches
-(sysroots, gcc toolchains) download from `download.jetbrains.com`, which the
-sandbox's egress policy still blocks. The failure looks like:
-
-```
-> Task :library:downloadKotlinNativeDistribution FAILED
-Cannot download a dependency https://download.jetbrains.com/kotlin/native/...:
-java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden"
-```
-
-after ten retries. This hits even targets this Linux host could otherwise
-build natively (`linuxX64`/`linuxArm64`), and through them `apiCheck` (its
-klib part), `publishToMavenLocal`, and `assembleKibanDebugXCFramework` (used
-by `samples/swift-console`, see #68). `./gradlew jvmTest` is unaffected: the
-JVM target never touches the Kotlin/Native compiler. Don't route around it
-(no mirrors, no disabling targets in a committed change) — disclose it in the
-PR instead.
-
 ## Android tasks need an SDK the sandbox doesn't have
 
 Android-*specific* tasks (`:library:testAndroidHostTest`,
 `assembleAndroidMain`, lint) fail with "SDK location not found. Define a
 valid SDK location with an ANDROID_HOME environment variable". That's a
 missing Android SDK installation, not a network or code problem. JVM tasks
-are unaffected — the Android target's mere presence in the build no longer
-breaks anything.
+are unaffected — the Android target's presence in the build breaks nothing
+else.
 
-## What "verified" should mean when local verification is blocked
+## What "verified" should mean when local verification is incomplete
 
-Don't claim untested changes pass. `jvmTest` and `jvmApiCheck` run fully
-here; Kotlin/Native compilation, the klib side of `apiCheck`, Apple targets,
-and Android-specific tasks don't. Say explicitly in the PR body which
-commands you ran and which targets were left unverified.
-`.github/workflows/gradle.yml` runs the full target matrix across Linux and
-macOS runners with unrestricted network access — that's the actual
-verification once the PR is pushed.
+Don't claim untested changes pass. `jvmTest`, the full `apiCheck`,
+`ktfmtCheck` and the Linux-host Kotlin/Native tasks all run here and count
+as real verification. Apple-target compilation/tests and Android-specific
+tasks don't run here — say explicitly in the PR body which commands you ran
+and which targets were left unverified. `.github/workflows/gradle.yml` runs
+the full target matrix across Linux and macOS runners — that's the actual
+verification once the PR is pushed, and `ios-interop-verify.yml` covers
+anything Swift-facing on demand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,56 +6,20 @@ real limitations that look like build breakage at first glance but aren't.
 Read this before spending time diagnosing a `./gradlew` failure as a code
 regression.
 
-## Network egress may be restricted
-
-`library/build.gradle.kts` applies `com.android.kotlin.multiplatform.library`
-(AGP) unconditionally — the module always declares an `androidLibrary {}`
-target, there's no way to opt out of it per-invocation. That plugin can only
-be resolved from Google's Maven repo (`dl.google.com`).
-
-If the sandbox's egress policy blocks `dl.google.com`, **every**
-`./gradlew` invocation fails during Gradle's configuration phase, before any
-task runs — including plain `./gradlew jvmTest`, not just Android- or
-`apiCheck`-specific tasks. The failure looks like:
-
-```
-Plugin [id: 'com.android.kotlin.multiplatform.library', version: '...', apply: false] was not found in any of the following sources:
-...
-    Google
-    MavenRepo
-    Gradle Central Plugin Repository
-```
-
-If you hit exactly this — a plugin-resolution failure against Google's Maven
-repo, reproducible on a clean `main` checkout with no changes of yours
-involved — it's this sandbox limitation, not a regression. Don't try to route
-around it (no mirrors, no repository substitution, no disabling AGP in a
-committed change). Disclose it in the PR instead.
-
-**Workaround to still run JVM-only checks locally:** temporarily remove the
-Android target so the AGP plugin never needs to resolve, run the checks, then
-revert before committing:
-
-1. In `build.gradle.kts`, drop the `alias(libs.plugins.android.kotlin.multiplatform.library) apply false` line.
-2. In `library/build.gradle.kts`, drop the `alias(libs.plugins.android.kotlin.multiplatform.library)` line and the `androidLibrary { ... }` block.
-3. Run `./gradlew jvmTest` / `./gradlew apiCheck` (the latter will still only cover targets buildable on this host — see below).
-4. `git checkout -- build.gradle.kts library/build.gradle.kts` to revert both files before staging anything. The committed diff must never include this workaround.
-
-With the Android target gone, `library/api/`'s expected dump path changes
-from nested (`library/api/jvm/library.api`) to flat (`library/api/library.api`),
-so `jvmApiCheck`/`apiCheck` fails with a "file does not exist" error against
-the real (nested) dump even when the API itself is unchanged. That failure is
-an artifact of the workaround, not a real API mismatch — don't act on it (no
-regenerating dumps, no restructuring `library/api/`) unless you've also
-confirmed a real API change some other way.
+The JVM side works normally: plain `./gradlew jvmTest`, `jvmApiCheck`,
+`ktfmtCheck`, `:samples:jvm-cli:run` and friends run out of the box, with no
+workarounds. (Older revisions of this file documented an egress block on
+`dl.google.com` that broke every `./gradlew` invocation at configuration time
+and required temporarily removing the Android target; that restriction has
+been lifted, and the workaround is gone with it.) The gaps that remain are
+below.
 
 ## No Apple toolchain in most cloud sandboxes
 
 Targets that need Xcode/macOS — `ios*`, `macos*`, `tvos*`, `watchos*` — can't
 be compiled or tested on a Linux container. `apiCheck` builds a klib for
 *every* declared target (see `library/build.gradle.kts`'s target list), so it
-also needs the Apple toolchain and can't fully pass here even once the AGP
-block above is worked around.
+also needs the Apple toolchain and can't fully pass here.
 
 This also blocks anything that requires actually running Swift-facing code
 (e.g. reviewing how the API surfaces through Objective-C interop or Swift
@@ -70,33 +34,43 @@ also builds and runs `samples/swift-console` (#68) — the concrete testbed
 #9's actual API review needs — so Swift Export artifact generation for that
 sample is the only piece #9 still has to add.
 
-## Kotlin/Native compiler distribution download may also be blocked
+## Kotlin/Native toolchain dependencies can't download
 
-Separately from the two egress restrictions above: any task that needs to
-*compile* a Kotlin/Native target — not just Apple ones — downloads the
-Kotlin/Native compiler distribution from `download.jetbrains.com` the first
-time it's needed, into `~/.konan`. If the sandbox's egress policy blocks that
-host too, this fails even for targets this Linux host could otherwise build
-natively, like `linuxX64`/`linuxArm64`. The failure looks like:
+Any task that needs to *compile* a Kotlin/Native target — not just Apple
+ones — still fails here. The compiler distribution itself resolves fine (it
+comes from Maven Central), but the platform toolchain bundles it then fetches
+(sysroots, gcc toolchains) download from `download.jetbrains.com`, which the
+sandbox's egress policy still blocks. The failure looks like:
 
 ```
-Cannot download a dependency https://download.jetbrains.com/kotlin/native/...: java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden"
+> Task :library:downloadKotlinNativeDistribution FAILED
+Cannot download a dependency https://download.jetbrains.com/kotlin/native/...:
+java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden"
 ```
 
-This means `apiCheck`, `publishToMavenLocal`, and
-`assembleKibanDebugXCFramework` (used by `samples/swift-console`, see #68) can
-all fail here for a *third* reason beyond the AGP and Apple-toolchain gaps
-above — even after working around both of those. `./gradlew jvmTest` is
-unaffected: the JVM target never touches the Kotlin/Native compiler. As with
-the other two gaps, don't route around it (no mirrors, no disabling targets
-in a committed change) — disclose it in the PR.
+after ten retries. This hits even targets this Linux host could otherwise
+build natively (`linuxX64`/`linuxArm64`), and through them `apiCheck` (its
+klib part), `publishToMavenLocal`, and `assembleKibanDebugXCFramework` (used
+by `samples/swift-console`, see #68). `./gradlew jvmTest` is unaffected: the
+JVM target never touches the Kotlin/Native compiler. Don't route around it
+(no mirrors, no disabling targets in a committed change) — disclose it in the
+PR instead.
+
+## Android tasks need an SDK the sandbox doesn't have
+
+Android-*specific* tasks (`:library:testAndroidHostTest`,
+`assembleAndroidMain`, lint) fail with "SDK location not found. Define a
+valid SDK location with an ANDROID_HOME environment variable". That's a
+missing Android SDK installation, not a network or code problem. JVM tasks
+are unaffected — the Android target's mere presence in the build no longer
+breaks anything.
 
 ## What "verified" should mean when local verification is blocked
 
-Don't claim untested changes pass. If `jvmTest`/`apiCheck` couldn't be run
-(or could only be run with the Android-target workaround above, or could only
-cover a subset of targets), say so explicitly in the PR body: which commands
-you ran, which workaround (if any) you used, and which targets were left
-unverified. `.github/workflows/gradle.yml` runs the full target matrix across
-Linux and macOS runners with unrestricted network access — that's the actual
+Don't claim untested changes pass. `jvmTest` and `jvmApiCheck` run fully
+here; Kotlin/Native compilation, the klib side of `apiCheck`, Apple targets,
+and Android-specific tasks don't. Say explicitly in the PR body which
+commands you ran and which targets were left unverified.
+`.github/workflows/gradle.yml` runs the full target matrix across Linux and
+macOS runners with unrestricted network access — that's the actual
 verification once the PR is pushed.


### PR DESCRIPTION
Rewrites `CLAUDE.md` to match the sandbox's current network policy, after the egress settings were updated (first `dl.google.com`, then `*.jetbrains.com`). Every claim was re-verified against a clean checkout of `main` in the same cloud sandbox the notes are written for.

## What changed

- **Removed** the "Network egress may be restricted" section and its Android-target-removal workaround. `dl.google.com` resolves, so AGP applies normally: plain `./gradlew jvmTest` and `./gradlew jvmApiCheck` pass out of the box. The note about the flat-vs-nested `library/api/` dump path — an artifact of that workaround — is gone with it.
- **Removed** the Kotlin/Native toolchain-download section. With `*.jetbrains.com` allowlisted (the blocking hop was actually `download-cdn.jetbrains.com`, which `download.jetbrains.com` 302-redirects to), `:library:downloadKotlinNativeDistribution` succeeds and Native work is fully unblocked on this host: `compileKotlinLinuxX64`, `linuxX64Test`, and the full `apiCheck` — `klibApiCheck` included, with the unbuildable Apple targets inferred — all pass.
- **Corrected the Apple-toolchain section**: it still notes that Apple targets and `assembleKibanDebugXCFramework` need a macOS host, but no longer claims `apiCheck` can't pass here (it can, via klib target inference).
- **Added a short section on Android-specific tasks**: `:library:testAndroidHostTest` fails with "SDK location not found ... ANDROID_HOME" — a missing SDK installation, not a network or code problem.
- **Simplified the "what verified should mean" section**: `jvmTest`, full `apiCheck`, `ktfmtCheck` and Linux-host Native tasks count as run-locally now; Apple-target and Android-task coverage still lands in `gradle.yml` on push.

## Verification

All on a clean checkout of current `main`, no build-file modifications:

- `./gradlew jvmTest` — BUILD SUCCESSFUL
- `./gradlew apiCheck` — BUILD SUCCESSFUL (`jvmApiCheck` + `klibApiCheck`)
- `./gradlew :library:compileKotlinLinuxX64` — BUILD SUCCESSFUL (toolchain bundles downloaded)
- `./gradlew :library:linuxX64Test` — BUILD SUCCESSFUL
- `./gradlew :library:testAndroidHostTest` — fails with the "SDK location not found" error quoted in the new Android section

The change itself is docs-only (`CLAUDE.md`), so CI is unaffected by content.