### PR TITLE
CI: upload test, lint and format reports as artifacts on failure

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,39 +16,56 @@ jobs:
   build:
     strategy:
       matrix:
+        # 'id' is the slug used in artifact names and step conditions: matrix
+        # targets contain spaces and colons, which are not valid in artifact
+        # names, and would collide once sanitised away.
         include:
           - target: iosSimulatorArm64Test
+            id: ios-simulator-arm64-test
             os: macos-latest
           - target: macosArm64Test
+            id: macos-arm64-test
             os: macos-latest
           - target: tvosSimulatorArm64Test
+            id: tvos-simulator-arm64-test
             os: macos-latest
           - target: watchosSimulatorArm64Test
+            id: watchos-simulator-arm64-test
             os: macos-latest
           - target: jvmTest
+            id: jvm-test
             os: ubuntu-latest
           - target: linuxX64Test
+            id: linux-x64-test
             os: ubuntu-latest
           - target: jsTest
+            id: js-test
             os: ubuntu-latest
           - target: wasmJsTest
+            id: wasm-js-test
             os: ubuntu-latest
           # Targets with no runner to execute on: cross-compile only.
           - target: compileKotlinLinuxArm64 compileKotlinMingwX64
+            id: cross-compile
             os: ubuntu-latest
           # apiCheck builds a klib for every target the host supports, so it
           # doubles as the compile check for the Apple targets.
           - target: apiCheck
+            id: api-check
             os: macos-latest
           - target: assembleAndroidMain androidCompileLintChecks :library:testAndroidHostTest
+            id: android
             os: ubuntu-latest
           # Generation only, no deploy: catches broken KDoc/sourceLink before a
           # release tag is cut. Actual publish to GitHub Pages stays in publish.yml.
           - target: :library:dokkaGeneratePublicationHtml
+            id: dokka
             os: ubuntu-latest
           - target: ktfmtCheck
+            id: ktfmt-check
             os: ubuntu-latest
           - target: :samples:jvm-cli:run
+            id: samples-jvm-cli-run
             os: ubuntu-latest
     runs-on: ${{ matrix.os }}
 
@@ -76,20 +93,43 @@ jobs:
         cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
     - name: Build with Gradle
-      run: ./gradlew ${{ matrix.target }}
+      # 'shell: bash' enables pipefail, so tee does not mask a Gradle failure.
+      # The log is the only diagnosable output for targets that write no report
+      # of their own (e.g. ':samples:jvm-cli:run').
+      shell: bash
+      run: |
+        mkdir -p build/reports/ci
+        ./gradlew ${{ matrix.target }} 2>&1 | tee build/reports/ci/gradle-build.log
 
     - name: Upload API docs preview
-      if: matrix.target == ':library:dokkaGeneratePublicationHtml'
+      if: matrix.id == 'dokka'
       uses: actions/upload-artifact@v7
       with:
         name: api-docs-preview
         path: library/build/dokka/html
         retention-days: 7
 
-    - name: Upload test reports
-      if: failure() && contains(matrix.target, 'Test')
+    - name: Generate ktfmt diff
+      # ktfmtCheck fails with a bare file list; re-formatting turns that into a
+      # patch that can be downloaded and applied.
+      if: failure() && matrix.id == 'ktfmt-check'
+      shell: bash
+      run: |
+        ./gradlew ktfmtFormat || true
+        mkdir -p build/reports/ktfmt
+        git diff > build/reports/ktfmt/ktfmt.patch
+
+    - name: Upload failure reports
+      if: failure()
       uses: actions/upload-artifact@v7
       with:
-        name: test-reports-${{ matrix.target }}-${{ matrix.os }}
-        path: library/build/reports/tests/
+        name: reports-${{ matrix.id }}-${{ matrix.os }}
+        path: |
+          **/build/reports/**
+          **/build/test-results/**
+          **/build/api/**
+          !**/build/reports/configuration-cache/**
+        # Not every target writes every kind of report; an empty match is not
+        # itself a failure worth flagging.
+        if-no-files-found: ignore
         retention-days: 7


### PR DESCRIPTION
## What changed

`.github/workflows/gradle.yml` only uploaded reports when the matrix target contained `Test`, and only from `library/build/reports/tests/`. Every other red entry — Android Lint, `apiCheck`, `ktfmtCheck`, `:library:testAndroidHostTest`, `:samples:jvm-cli:run` — left nothing but scrollback.

- **Widened the failure upload** to `**/build/reports/**`, `**/build/test-results/**` and `**/build/api/**`, gated on `failure()` alone. `library/build/api/` is where binary-compatibility-validator writes the *actual* dump (verified locally: `library/build/api/jvm/library.api` and `library/build/api/klib/library.klib.api`), so an `apiCheck` mismatch is now diffable from the artifact without an Apple toolchain to reproduce it. Gradle's `build/reports/configuration-cache/**` is excluded as opaque noise.
- **Captured the Gradle log** to `build/reports/ci/gradle-build.log` via `tee`, so targets that write no report of their own — `:samples:jvm-cli:run` above all — still leave something downloadable. The step declares `shell: bash`, which turns on `pipefail`, so the pipe cannot mask a failing build (checked: `bash -eo pipefail -c 'false | tee /dev/null'` exits 1).
- **ktfmt diff**: on a `ktfmtCheck` failure the workflow now runs `ktfmtFormat` and saves `git diff` as `build/reports/ktfmt/ktfmt.patch`, turning the bare file list into an applyable patch.
- **Artifact-name collisions**: each matrix entry gained an `id` slug (`api-check`, `android`, `samples-jvm-cli-run`, …). Targets contain spaces and colons, which are invalid in artifact names and would collide once sanitised. Artifact names and the Dokka-preview condition now key off `matrix.id`; the target strings themselves are unchanged.
- `retention-days: 7` kept, and `if-no-files-found: ignore` added so entries that legitimately produce no report don't flag a second failure.

Acceptance from the issue is met: every matrix entry now leaves at least the build log, and any entry producing a report leaves the report.

## Not done

No JUnit-XML PR-annotation action was added — that was a "consider" in the issue and means taking on a third-party action; the raw `**/build/test-results/**` XML is now in the artifact, so the input for one is available if it's wanted later. Happy to add it in a follow-up.

## Verification

Ran locally on Linux (per `CLAUDE.md`, this container has no Apple toolchain and no Android SDK):

- `./gradlew jvmTest apiCheck ktfmtCheck` — pass.
- YAML parses; the 14 matrix entries survive the edit with unique, `[a-z0-9-]`-only ids.
- `./gradlew ktfmtFormat --dry-run` — confirms the task resolves from the root invocation used in the new step.
- Confirmed the glob targets exist after a real run: `library/build/reports/tests/jvmTest/`, `library/build/test-results/jvmTest/*.xml`, `library/build/api/`.

This is a workflow-only change, so there are no unit tests to add; the real exercise is the CI run on this PR (green path). The failure paths — lint/apiCheck/ktfmt artifacts — can only be observed on an actually red run, and are unverified here beyond the path checks above.

Closes #107


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJwBEzWwkd4Y1UNoaK8i6W)_