### PR TITLE
CI: add a single aggregate check for branch rulesets

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,6 +14,10 @@ permissions:
 
 jobs:
   build:
+    # Named off 'matrix.id' alone, so the check name stays stable when a matrix
+    # key is added or reordered. The default name interpolates *every* matrix
+    # value, which is what renamed every check when 'id' was introduced.
+    name: ${{ matrix.id }} (${{ matrix.os }})
     strategy:
       matrix:
         # 'id' is the slug used in artifact names and step conditions: matrix
@@ -133,3 +137,22 @@ jobs:
         # itself a failure worth flagging.
         if-no-files-found: ignore
         retention-days: 7
+
+  # The single check a branch ruleset should require. 'needs' on a matrix job
+  # waits for every entry, so adding, renaming or removing a matrix target never
+  # touches the list of required checks.
+  ci:
+    name: CI
+    needs: build
+    # 'always()' is what makes this usable as a required check: without it the
+    # gate is skipped whenever a matrix entry fails, and a required check that
+    # never reports leaves the PR waiting forever instead of going red.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check matrix result
+      # 'needs.build.result' is the combined result of all matrix entries:
+      # 'success' only when every one of them succeeded.
+      run: |
+        echo "Build matrix result: ${{ needs.build.result }}"
+        test "${{ needs.build.result }}" = "success"


### PR DESCRIPTION
## Problem

Required status checks in a ruleset are matched **by name**, and a matrix job's default name is derived from *every* matrix value. So the names move whenever the matrix does — #120 added an `id` key and renamed all fourteen checks in one go (`build (jvmTest, ubuntu-latest)` → `build (jvmTest, jvm-test, ubuntu-latest)`). Any ruleset naming the old checks is stale as of that merge, and it will go stale again on the next matrix change.

## Change

- **New `ci` job, displayed as `CI`.** It declares `needs: build`; `needs` on a matrix job waits for every entry and collapses their outcomes into a single `needs.build.result`, which is `success` only when all of them succeeded. Requiring just this one check means adding, renaming or removing a matrix target never touches the ruleset again.
- It carries **`if: always()`**, which is the part that makes it safe as a required check. Without it the gate is *skipped* whenever a matrix entry fails — and a required check that never reports leaves the PR waiting indefinitely rather than going red.
- **The matrix job is now named off `matrix.id` alone** (`jvm-test (ubuntu-latest)`), so its check names stay stable if another matrix key is added or reordered later.

No third-party action: the gate is `test "${{ needs.build.result }}" = "success"`.

## Follow-up needed in repo settings (not doable from here)

After this merges, update the ruleset to require exactly one check — **`CI`** — and drop the individual `build (...)` entries. That is the last time the list should need editing. Note the matrix check names change again with this PR, so the ruleset needs that edit regardless.

## Verification

- YAML parses; both jobs resolve as expected (`build` name `${{ matrix.id }} (${{ matrix.os }})`, `ci` with `needs: build` and `if: always()`).
- The green path is exercised by this PR's own run: `CI` should appear as a check and pass once all 14 entries do.
- The red path — `CI` reporting failure rather than being skipped when an entry fails — is not exercised here, since nothing in this PR fails. It follows from `if: always()` plus `needs.build.result != 'success'`, but if you want it proven before you rewrite the ruleset, I can push a throwaway commit that breaks one matrix entry, show the check going red, and revert it.
- `publish.yml` is unaffected: it depends on the reusable workflow at the job level (`needs: test`), not on check names.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WJwBEzWwkd4Y1UNoaK8i6W)_