### PR TITLE
Clean up KDoc inherited from java-iban: stray @author and misleading @since tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 0.6.0 (unreleased)
 
+**Documentation**
+
+* Cleaned up KDoc inherited from `java-iban` (#108). The `Iban` class documentation had its
+  construction paragraph placed after an `@author` tag, which a KDoc block tag swallows — the
+  published API docs rendered that paragraph as part of the Author field instead of as the class
+  description. The paragraph moved above the block tags, and the `@author` tag was dropped;
+  attribution to Barend Garvelink stays where it already lives, in the per-file license headers and
+  the README. Also removed `@since 1.0.0` on `Iban` and `@since 1.9.0` on
+  `Modulo97.calculateCheckDigits`: those are `java-iban` versions, and kiban has never published a
+  1.x release.
+
 **Infrastructure**
 
 * Made the SWIFT registry sync (#53) able to run unattended. It regenerates and diffs the country data

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -23,18 +23,15 @@ import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
  * validation is performed, other than matching the length of the IBAN to its country code. Unknown
  * country codes are not supported.
  *
+ * Instances can only be obtained through [Iban.invoke] (`Iban(input)`) or [Iban.compose], which
+ * validate the input and throw an [IbanParseException] on failure. Construction itself never fails.
+ *
  * @property isInSwiftRegistry whether or not this IBAN data is from the SWIFT IBAN Registry.
  * @property isSEPA whether or not this IBAN is of a SEPA participating country.
  * @property plain the IBAN value, without any white space.
  * @property pretty the IBAN value, with spaces every four characters.
  * @see <a href="https://en.wikipedia.org/wiki/International_Bank_Account_Number">Wikipedia:
  *   International Bank Account Number</a>
- * @author Barend Garvelink https://github.com/barend
- *
- * Instances can only be obtained through [Iban.invoke] (`Iban(input)`) or [Iban.compose], which
- * validate the input and throw an [IbanParseException] on failure. Construction itself never fails.
- *
- * @since 1.0.0
  */
 class Iban private constructor(internal val value: String) : Comparable<Iban> {
     /**

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Modulo97.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Modulo97.kt
@@ -83,7 +83,6 @@ object Modulo97 {
      * @return the check digits to be used at indices 2 and 3 to make the input MOD97 verifiable.
      * @throws [IllegalArgumentException] if the country code is not two characters or contains a
      *   space character.
-     * @since 1.9.0
      */
     fun calculateCheckDigits(countryCode: CharSequence, bban: CharSequence): Int {
         if (countryCode.length != 2) {


### PR DESCRIPTION
Removes three KDoc tags carried over from the original `java-iban` port that are wrong now that the API docs are published at https://bijdorpstudio.github.io/kiban/.

## Changes

**`Iban.kt` — construction paragraph moved out of `@author`**

The paragraph describing how instances are obtained sat *after* the `@author` tag. A KDoc block tag consumes everything up to the next tag, so Dokka rendered that paragraph as part of the Author field instead of the class description. It now sits with the rest of the class description, above the first block tag.

**`Iban.kt` — `@author` dropped**

Attribution to Barend Garvelink is genuine and stays where it already lives: the `Copyright 2023 Barend Garvelink, Eugen Martynov` header at the top of every source file, and the README's Introduction/Design-choices sections. The tag's only effect was to repeat it on the `Iban` API reference page. The copyright headers are untouched.

**`Iban.kt` / `Modulo97.kt` — `@since 1.0.0` and `@since 1.9.0` dropped**

Both are `java-iban` version numbers. kiban's published line is 0.1.0–0.5.0 and it has never had a 1.x release, so as rendered they asserted availability since a version that does not exist for this artifact. Dropped rather than restated in kiban terms — there is no meaningful "since" story for a pre-1.0 library that has already broken its API twice.

**`CHANGELOG.md`** — a Documentation entry under 0.6.0 (unreleased).

Diff is comment-only in the two Kotlin files; no code, no public API change.

## Verification

Ran here and green:

- `./gradlew ktfmtCheck`
- `./gradlew jvmTest`
- `./gradlew apiCheck` (both `jvmApiCheck` and `klibApiCheck`, Apple targets inferred) — unchanged, as expected for a comment-only diff

No new tests: the change is documentation only and adds no behavior to cover.

Not verified here: `:library:dokkaGeneratePublicationHtml`, so the rendered output could not be inspected locally. The task resolves the Android target's dependencies and fails on this container with *"SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable"* — the missing-Android-SDK gap documented in `CLAUDE.md`, not a problem with this change. The acceptance criterion (the construction paragraph rendering as class description rather than under Author) follows from KDoc's block-tag scoping rule that caused the bug in the first place, and is worth a glance on the published docs after the next release.

Closes #108

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpZuigqXozgUFbeWghbb7z)_