### PR TITLE
CI: cache ~/.konan in publish.yml jobs (and fix the degenerate cache key in gradle.yml)

### DIFF
--- a/.github/actions/cache-konan/action.yml
+++ b/.github/actions/cache-konan/action.yml
@@ -1,0 +1,31 @@
+# Shared '~/.konan' cache step for every workflow that touches the Kotlin/Native
+# toolchain (#109).
+#
+# Every job that compiles a native target, and every job that runs Dokka, needs
+# the Kotlin/Native distribution: Dokka runs the Kotlin analysis frontend rather
+# than scraping comments, so it resolves 'nativeMain'/'appleMain' too and pulls
+# the platform klibs in through ':library:downloadKotlinNativeDistribution'.
+# Without this step that is a fresh 'download.jetbrains.com' fetch per job.
+#
+# The cache key is keyed on 'gradle/libs.versions.toml' because the 'kotlin'
+# version declared there is what decides which 'kotlin-native-prebuilt-*' bundle
+# gets downloaded. The previous key -- 'hashFiles(''**/.lock'')' -- matched no
+# tracked file, and 'hashFiles' returns an empty string when nothing matches, so
+# it collapsed to a constant 'Linux-'/'macOS-' that was never invalidated: after
+# a Kotlin bump the stale bundle was restored and the new one downloaded on top,
+# growing the entry every time.
+name: Cache Kotlin/Native distribution
+description: Restores and saves '~/.konan', keyed on the Kotlin version in the Gradle version catalog.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@v6
+      with:
+        path: |
+          ~/.konan
+        key: ${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}
+        # A version bump should miss the exact key and still restore the most
+        # recent entry for this runner, so the new bundle downloads against a
+        # warm cache instead of an empty one.
+        restore-keys: ${{ runner.os }}-konan-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,8 +47,13 @@ updates:
           - "minor"
           - "patch"
 
+  # '/' covers '.github/workflows'; the composite actions under
+  # '.github/actions' are separate manifests and need to be listed explicitly,
+  # otherwise the 'uses:' references inside them silently escape coverage.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/cache-konan"
     schedule:
       interval: "weekly"
     groups:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -76,11 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - uses: actions/cache@v6
-      with:
-        path: |
-          ~/.konan
-        key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
+    - uses: ./.github/actions/cache-konan
 
     - name: Set up JDK 25
       uses: actions/setup-java@v5

--- a/.github/workflows/ios-interop-verify.yml
+++ b/.github/workflows/ios-interop-verify.yml
@@ -35,11 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/cache@v6
-        with:
-          path: |
-            ~/.konan
-          key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
+      - uses: ./.github/actions/cache-konan
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
 
+      # 'publishToMavenCentral' runs with '-Pkotlin.native.ignoreDisabledTargets=false',
+      # so this job compiles every native target and needs the whole Kotlin/Native
+      # distribution.
+      - uses: ./.github/actions/cache-konan
+
       - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
@@ -59,6 +64,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
+
+      # Dokka resolves 'nativeMain'/'appleMain' through the Kotlin analysis
+      # frontend, so this job downloads the Kotlin/Native distribution as well --
+      # see the action's own comment.
+      - uses: ./.github/actions/cache-konan
 
       - name: Set up JDK 25
         uses: actions/setup-java@v5


### PR DESCRIPTION
## What changed

### New `.github/actions/cache-konan` composite action

The `~/.konan` cache step is now a single composite action instead of a block copy-pasted per workflow. Its key is `${{ runner.os }}-konan-${{ hashFiles('gradle/libs.versions.toml') }}`, with `restore-keys: ${{ runner.os }}-konan-`.

The catalog file is the right thing to key on: the `kotlin` version declared there is what decides which `kotlin-native-prebuilt-*` bundle gets downloaded. `restore-keys` keeps a warm partial hit on a version bump instead of a cold download.

### Fixed the degenerate key

Both existing copies used `key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}`. No `.lock` file is tracked, and `hashFiles` returns an empty string when nothing matches, so the key collapsed to a constant `Linux-` / `macOS-` that a Kotlin bump never invalidated — the stale bundle was restored and the new one downloaded on top, growing the entry every time.

### Added the cache to both `publish.yml` jobs

Neither had it, so every release downloaded the Kotlin/Native distribution twice:

- **Release build and publish** — runs `publishToMavenCentral` with `-Pkotlin.native.ignoreDisabledTargets=false`, i.e. compiles every native target.
- **Publish API docs** — Dokka runs the Kotlin analysis frontend rather than scraping comments, so it resolves `nativeMain`/`appleMain` and pulls in the platform klibs via `:library:downloadKotlinNativeDistribution`.

### Call sites converted

`gradle.yml`, both `publish.yml` jobs, and `ios-interop-verify.yml` — the last one carried the same degenerate key, and leaving it behind would have kept the stale-entry bug alive in the one workflow whose whole purpose is producing trustworthy Apple-target output.

### Dependabot

`directory: "/"` only covers `.github/workflows`; composite actions are separate manifests. The `github-actions` entry now uses `directories:` and lists `/.github/actions/cache-konan` so the `actions/cache@v6` reference inside it stays covered. Grouping is unchanged.

## Verification

- `./gradlew jvmTest apiCheck` — **BUILD SUCCESSFUL** (full `apiCheck`, including `klibApiCheck` with the Apple targets inferred). No public API change, so no `apiDump`.
- All five touched/added YAML files parse.
- Every `uses: ./.github/actions/cache-konan` sits after its job's `actions/checkout` step, which a local action requires.

No Kotlin source changed, and this repo has no harness for exercising workflow YAML, so there are no new tests — the change is verified by the release run itself: `downloadKotlinNativeDistribution` should be a cache hit in both `publish.yml` jobs. The cache key behaviour on a Kotlin bump can't be observed until the next bump lands.

Closes #109

---
_Generated by [Claude Code](https://claude.ai/code/session_01QawTdgJ4EXLGQcUgqbDwpv)_