### PR TITLE
Migrate the test suite from kotlin.test to TestBalloon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@
 
 **Infrastructure**
 
+* Migrated the test suite from `kotlin.test` to [TestBalloon](https://github.com/infix-de/testBalloon)
+  (#115), acting on the evaluation in `docs/82-testballoon-evaluation.md`. The country table used to be
+  folded into an assertk `Table1` and looped inside a handful of `@Test` methods, so all 111 countries
+  collapsed into 3 reported cases: a registry update that broke one country failed one opaque test and
+  stopped the loop, which is exactly the report a reviewer reads first on the automated registry-sync
+  pull requests. Each country now registers as its own test — `Length for Albania should return correct
+  value`, `Compose should round trip Albania`, and so on — taking the suite from 78 reported tests to
+  1,217 with no loss of coverage. Assertions are untouched: assertk stays, and the ~40 `assertFailsWith`
+  call sites became `assertFailure { … }.isInstanceOf<…>()`. `kotlin-test` is dropped from `commonTest`
+  entirely. TestBalloon is a compiler plugin plus a test-only dependency and registers no new Gradle test
+  tasks, so the published artifacts still declare `kotlin-stdlib` as their only dependency and the CI
+  target matrix needed no changes.
+
 * Made the SWIFT registry sync (#53) able to run unattended. It regenerates and diffs the country data
   before asking for a registry revision, so the ~50 runs a year that find nothing finish silently and only
   a real registry change interrupts a maintainer — the release number is not published anywhere

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ assertk = "0.28.1"
 dokka = "2.2.0"
 # @keep this is library java compatibility version
 java-version = "17"
+junit = "4.13.2"
 kotlin = "2.4.10"
 kotlinx-binary-compatibility-validator = "0.18.1"
 # @keep this is library kotlin compatibility version
@@ -15,11 +16,17 @@ kotlin-version = "2.3.0"
 ktfmt-plugin = "0.27.0"
 maven-publish-plugin = "0.37.0"
 tapmoc-plugin = "0.4.2"
+# Test-only. 1.1.0-RC is the first unified release: one artifact set auto-adapting to the Kotlin
+# compiler in use (2.2.0+), instead of 1.0.x's per-Kotlin-version variants, which would have made
+# every Kotlin bump a coupled TestBalloon bump. Move to 1.1.0 once it ships; it is binary
+# compatible, so the bump is this line alone. See docs/82-testballoon-evaluation.md.
+testballoon = "1.1.0-RC"
 versions-catalogue-update-plugin = "1.1.1"
 
 [libraries]
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+junit = { module = "junit:junit", version.ref = "junit" }
+testballoon-framework-core = { module = "de.infix.testBalloon:testBalloon-framework-core", version.ref = "testballoon" }
 
 [plugins]
 android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
@@ -30,4 +37,5 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlinx-api-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility-validator" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-plugin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish-plugin" }
+testballoon = { id = "de.infix.testBalloon", version.ref = "testballoon" }
 versions-catalogue-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "versions-catalogue-update-plugin" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.maven.publish)
     alias(libs.plugins.dokka)
     alias(libs.plugins.ktfmt)
+    alias(libs.plugins.testballoon)
 }
 
 group = "nl.bijdorpstudio.kiban"
@@ -74,8 +75,11 @@ kotlin {
     sourceSets {
         commonTest.dependencies {
             implementation(libs.assertk)
-            implementation(libs.kotlin.test)
+            implementation(libs.testballoon.framework.core)
         }
+        // TestBalloon runs Android host-side tests through the JUnit 4 runner, which the Android
+        // target does not put on the test classpath by itself.
+        named("androidHostTest").dependencies { implementation(libs.junit) }
     }
 }
 

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesParameterizedTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesParameterizedTest.kt
@@ -15,56 +15,41 @@
 */
 package nl.bijdorpstudio.kiban
 
-import assertk.Table1
 import assertk.assertThat
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
-import assertk.tableOf
-import kotlin.test.Test
+import de.infix.testBalloon.framework.core.testSuite
+
+/**
+ * List of valid international IBAN's, ordered by country name so the generated test cases report in
+ * a stable order. References:
+ * - SWIFT: https://www.swift.com/standards/data-standards/iban
+ * - IBAN.com Experimental List: https://www.iban.com/structure
+ */
+internal val countriesTestData = countryTestData.sortedBy { it.name }
 
 /**
  * Ensures that the [Iban] class accepts IBAN numbers from every participating country (...known at
  * the time the test was last updated).
  */
-class CountryCodesParameterizedTest {
-
-    @Test
-    fun `Length for country code should return correct value`() {
-        countriesTestDataTable.forAll { testData ->
+val CountryCodesParameterizedTest by testSuite {
+    for (testData in countriesTestData) {
+        test("Length for ${testData.name} should return correct value") {
             val lengthForCountryCode = CountryCodes.getLength(testData.plain.substring(0, 2)) ?: -1
             assertThat(lengthForCountryCode).isEqualTo(testData.plain.length)
         }
     }
 
-    @Test
-    fun `Is known country code should return true`() {
-        countriesTestDataTable.forAll { td ->
-            assertThat(CountryCodes.isKnownCountryCode(td.plain.substring(0, 2))).isTrue()
+    for (testData in countriesTestData) {
+        test("${testData.name} should be a known country code") {
+            assertThat(CountryCodes.isKnownCountryCode(testData.plain.substring(0, 2))).isTrue()
         }
     }
 
-    @Test
-    fun `All country codes should be tested`() {
-        val testDataCountryCodes = testData.map { it.plain.substring(0, 2) }.toSet()
+    test("All country codes should be tested") {
+        val testDataCountryCodes = countriesTestData.map { it.plain.substring(0, 2) }.toSet()
 
         assertThat(CountryCodes.knownCountryCodes.toSet() - testDataCountryCodes).isEmpty()
-    }
-
-    companion object {
-        /**
-         * List of valid international IBAN's. References:
-         * - SWIFT: https://www.swift.com/standards/data-standards/iban
-         * - IBAN.com Experimental List: https://www.iban.com/structure
-         */
-        val testData = countryTestData.sortedBy { it.name }
-
-        // Table for parametrized tests
-        val countriesTestDataTable =
-            tableOf("Test data").run {
-                var table: Table1<IbanCountryTestData>? = null
-                testData.forEach { table = table?.row(it) ?: row(it) }
-                requireNotNull(table)
-            }
     }
 }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
@@ -25,7 +25,9 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import de.infix.testBalloon.framework.core.TestConfig
+import de.infix.testBalloon.framework.core.TestPlatform
 import de.infix.testBalloon.framework.core.disable
+import de.infix.testBalloon.framework.core.testPlatform
 import de.infix.testBalloon.framework.core.testSuite
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -34,7 +36,13 @@ import kotlin.time.Instant
 val CountryCodesTest by testSuite {
     test(
         "Known country codes should not be editable",
-        testConfig = TestConfig.disable(), // Fails on Kotlin native
+        // JVM only. There, Collection and MutableCollection erase to the same type, so the cast
+        // is a runtime no-op and `add` reaches the fixed-size list backing `asList()`, which
+        // rejects it with UnsupportedOperationException. Every other target checks the cast and
+        // throws ClassCastException first — the collection is just as immutable there, but this
+        // test asserts the JVM's particular way of saying so.
+        testConfig =
+            if (testPlatform.type == TestPlatform.Type.Jvm) TestConfig else TestConfig.disable(),
     ) {
         // Not meant to be an exhaustive test, just a reminder to keep API consistent if
         // implementation changes.

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
@@ -15,61 +15,57 @@
 */
 package nl.bijdorpstudio.kiban
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isBetween
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
-import kotlin.test.Ignore
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.TestConfig
+import de.infix.testBalloon.framework.core.disable
+import de.infix.testBalloon.framework.core.testSuite
 import kotlin.time.Clock
 import kotlin.time.Instant
 
 /** Some tests for [CountryCodes]. */
-class CountryCodesTest {
-
-    @Ignore // Fails on Kotlin native
-    @Test
-    fun `Known country codes should not be editable`() {
+val CountryCodesTest by testSuite {
+    test(
+        "Known country codes should not be editable",
+        testConfig = TestConfig.disable(), // Fails on Kotlin native
+    ) {
         // Not meant to be an exhaustive test, just a reminder to keep API consistent if
         // implementation changes.
-        assertFailsWith<UnsupportedOperationException> {
-            (CountryCodes.knownCountryCodes as MutableCollection<String>).add("ZZ")
-        }
+        @Suppress("UNCHECKED_CAST")
+        assertFailure { (CountryCodes.knownCountryCodes as MutableCollection<String>).add("ZZ") }
+            .isInstanceOf<UnsupportedOperationException>()
     }
 
-    @Test
-    fun `Known country codes should be in ascending order`() {
+    test("Known country codes should be in ascending order") {
         val raw = CountryCodes.knownCountryCodes
 
         assertThat(raw.sorted()).isEqualTo(raw)
     }
 
-    @Test
-    fun `isKnownCountryCode should return false for empty string`() {
+    test("isKnownCountryCode should return false for empty string") {
         assertThat(CountryCodes.isKnownCountryCode("")).isFalse()
     }
 
-    @Test
-    fun `isKnownCountryCode should return false for lowercase`() {
+    test("isKnownCountryCode should return false for lowercase") {
         assertThat(CountryCodes.isKnownCountryCode("nl")).isFalse()
     }
 
-    @Test
-    fun `isKnownCountryCode should return true for existing country code`() {
+    test("isKnownCountryCode should return true for existing country code") {
         assertThat(CountryCodes.isKnownCountryCode("NL")).isTrue()
     }
 
-    @Test
-    fun `getLength returns null for unknown country code`() {
+    test("getLength returns null for unknown country code") {
         assertThat(CountryCodes.getLength("XX")).isNull()
     }
 
-    @Test
-    fun `lastUpdateDate should not be null`() {
+    test("lastUpdateDate should not be null") {
         assertThat(CountryCodes.lastUpdateDate)
             .isNotNull()
             .isBetween(
@@ -78,8 +74,7 @@ class CountryCodesTest {
             )
     }
 
-    @Test
-    fun `lastUpdateRevision should not be null`() {
+    test("lastUpdateRevision should not be null") {
         assertThat(CountryCodes.lastUpdateRevision).isNotNull()
     }
 }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanFieldTest.kt
@@ -18,26 +18,24 @@ package nl.bijdorpstudio.kiban
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import kotlin.test.Test
+import de.infix.testBalloon.framework.core.testSuite
 
 /**
  * Ensures that the [Iban] class accepts IBAN numbers from every participating country (...known at
  * the time the test was last updated).
  */
-class CountryCodesIbanFieldsTest {
-    @Test
-    fun `Should extract bank identifier`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val iban = Iban(td.plain)
-            assertThat(iban.bankIdentifier).isEqualTo(td.bank)
+val CountryCodesIbanFieldsTest by testSuite {
+    for (testData in countriesTestData) {
+        test("Should extract bank identifier for ${testData.name}") {
+            val iban = Iban(testData.plain)
+            assertThat(iban.bankIdentifier).isEqualTo(testData.bank)
         }
     }
 
-    @Test
-    fun `Should extract branch identifier`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val iban = Iban(td.plain)
-            assertThat(iban.branchIdentifier).isEqualTo(td.branch)
+    for (testData in countriesTestData) {
+        test("Should extract branch identifier for ${testData.name}") {
+            val iban = Iban(testData.plain)
+            assertThat(iban.branchIdentifier).isEqualTo(testData.branch)
         }
     }
 }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
@@ -17,62 +17,56 @@ package nl.bijdorpstudio.kiban
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import kotlin.test.Test
+import de.infix.testBalloon.framework.core.testSuite
 
 /**
  * Ensures that the [Iban] class accepts IBAN numbers from every participating country (...known at
  * the time the test was last updated).
  */
-class IbanInternationalTest {
-    @Test
-    fun `Parse should accept plain form`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { testData ->
+val IbanInternationalTest by testSuite {
+    for (testData in countriesTestData) {
+        test("Parse should accept plain form for ${testData.name}") {
             val iban = Iban(testData.plain)
             assertThat(iban.plain).isEqualTo(testData.plain)
             assertThat(iban.toString()).isEqualTo(testData.pretty)
         }
     }
 
-    @Test
-    fun `Parse should accept pretty printed form`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val iban = Iban(td.pretty)
-            assertThat(iban.plain).isEqualTo(td.plain)
-            assertThat(iban.toString()).isEqualTo(td.pretty)
+    for (testData in countriesTestData) {
+        test("Parse should accept pretty printed form for ${testData.name}") {
+            val iban = Iban(testData.pretty)
+            assertThat(iban.plain).isEqualTo(testData.plain)
+            assertThat(iban.toString()).isEqualTo(testData.pretty)
         }
     }
 
-    @Test
-    fun `Compose should round trip every country`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
+    for (testData in countriesTestData) {
+        test("Compose should round trip ${testData.name}") {
             val composed =
                 Iban.compose(
-                    countryCode = td.plain.substring(0, 2),
-                    bban = td.plain.substring(4),
+                    countryCode = testData.plain.substring(0, 2),
+                    bban = testData.plain.substring(4),
                 )
-            assertThat(composed).isEqualTo(Iban(td.plain))
+            assertThat(composed).isEqualTo(Iban(testData.plain))
         }
     }
 
-    @Test
-    fun `Check is registered IBAN`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            assertThat(Iban(td.plain).isInSwiftRegistry).isEqualTo(td.swift)
+    for (testData in countriesTestData) {
+        test("Check is registered IBAN for ${testData.name}") {
+            assertThat(Iban(testData.plain).isInSwiftRegistry).isEqualTo(testData.swift)
         }
     }
 
-    @Test
-    fun `Check is SEPA country`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            assertThat(Iban(td.plain).isSEPA).isEqualTo(td.sepa)
+    for (testData in countriesTestData) {
+        test("Check is SEPA country for ${testData.name}") {
+            assertThat(Iban(testData.plain).isSEPA).isEqualTo(testData.sepa)
         }
     }
 
-    @Test
-    fun `Get length for country code should return correct value`() {
-        CountryCodesParameterizedTest.countriesTestDataTable.forAll { td ->
-            val lengthForCountryCode = CountryCodes.getLength(td.plain.substring(0, 2)) ?: -1
-            assertThat(lengthForCountryCode).isEqualTo(td.plain.length)
+    for (testData in countriesTestData) {
+        test("Get length for country code should return correct value for ${testData.name}") {
+            val lengthForCountryCode = CountryCodes.getLength(testData.plain.substring(0, 2)) ?: -1
+            assertThat(lengthForCountryCode).isEqualTo(testData.plain.length)
         }
     }
 }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -15,8 +15,10 @@
 */
 package nl.bijdorpstudio.kiban
 
+import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
@@ -47,19 +49,6 @@ private val rejectionKindInputs =
         VALID_IBAN + "0",
         INVALID_IBAN,
     )
-
-/**
- * Asserts that [block] fails with an [IbanParseException] and returns the
- * [IbanParseException.Malformed.Kind] it carries, or `null` if it was not a
- * [IbanParseException.Malformed].
- */
-private fun malformedKind(block: () -> Unit): IbanParseException.Malformed.Kind? {
-    var kind: IbanParseException.Malformed.Kind? = null
-    assertFailure { block() }
-        .isInstanceOf<IbanParseException>()
-        .given { failure -> kind = (failure as? IbanParseException.Malformed)?.kind }
-    return kind
-}
 
 /** Miscellaneous tests for the [Iban] class. */
 val IbanTest by testSuite {
@@ -124,77 +113,77 @@ val IbanTest by testSuite {
     }
 
     test("Invoke should reject empty input") {
-        assertThat(malformedKind { Iban("") }).isEqualTo(IbanParseException.Malformed.Kind.EMPTY)
+        assertFailure { Iban("") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .prop(IbanParseException.Malformed::kind)
+            .isEqualTo(IbanParseException.Malformed.Kind.EMPTY)
     }
 
     test("Invoke should reject invalid input") {
         assertFailure { Iban("Shenanigans!") }
             .isInstanceOf<IbanParseException.Malformed>()
-            .given { failure ->
-                assertThat(failure.kind)
+            .all {
+                prop(IbanParseException.Malformed::kind)
                     .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
-                assertThat(failure.message)
-                    .isEqualTo("Input begins or ends in an invalid character: Shenanigans!")
+                hasMessage("Input begins or ends in an invalid character: Shenanigans!")
             }
     }
 
     test("Invoke should reject leading whitespace") {
         assertFailure { Iban(" $VALID_IBAN") }
             .isInstanceOf<IbanParseException.Malformed>()
-            .given { failure ->
-                assertThat(failure.kind)
+            .all {
+                prop(IbanParseException.Malformed::kind)
                     .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
-                assertThat(failure.message)
-                    .isEqualTo("Input begins or ends in an invalid character:  $VALID_IBAN")
+                hasMessage("Input begins or ends in an invalid character:  $VALID_IBAN")
             }
     }
 
     test("Invoke should reject trailing whitespace") {
         assertFailure { Iban("$VALID_IBAN ") }
             .isInstanceOf<IbanParseException.Malformed>()
-            .given { failure ->
-                assertThat(failure.kind)
+            .all {
+                prop(IbanParseException.Malformed::kind)
                     .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
-                assertThat(failure.message)
-                    .isEqualTo("Input begins or ends in an invalid character: $VALID_IBAN ")
+                hasMessage("Input begins or ends in an invalid character: $VALID_IBAN ")
             }
     }
 
     test("Invoke should reject too short input") {
         assertFailure { Iban("NL03") }
             .isInstanceOf<IbanParseException.Malformed>()
-            .given { failure ->
-                assertThat(failure.kind).isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
-                assertThat(failure.message).isEqualTo("Length is too short to be an IBAN: NL03")
+            .all {
+                prop(IbanParseException.Malformed::kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
+                hasMessage("Length is too short to be an IBAN: NL03")
             }
     }
 
     test("Invoke should reject non numeric check digits") {
         assertFailure { Iban("NLAB0143267469") }
             .isInstanceOf<IbanParseException.Malformed>()
-            .given { failure ->
-                assertThat(failure.kind)
+            .all {
+                prop(IbanParseException.Malformed::kind)
                     .isEqualTo(IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS)
-                assertThat(failure.message)
-                    .isEqualTo("Characters at index 2 and 3 not both numeric. NLAB0143267469")
+                hasMessage("Characters at index 2 and 3 not both numeric. NLAB0143267469")
             }
     }
 
     test("Invoke should reject unsupported characters") {
         val invalidCharacter = VALID_IBAN.replaceRange(6, 7, "_")
 
-        assertThat(malformedKind { Iban(invalidCharacter) })
+        assertFailure { Iban(invalidCharacter) }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .prop(IbanParseException.Malformed::kind)
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
     }
 
     test("Invoke should reject unknown country code") {
         assertFailure { Iban("UU345678345543234") }
             .isInstanceOf<IbanParseException.UnknownCountryCode>()
-            .given { failure ->
-                assertThat(failure)
-                    .prop(IbanParseException.UnknownCountryCode::countryCode)
-                    .isEqualTo("UU")
-                assertThat(failure.message).isEqualTo("Unknown country code: UU")
+            .all {
+                prop(IbanParseException.UnknownCountryCode::countryCode).isEqualTo("UU")
+                hasMessage("Unknown country code: UU")
             }
     }
 
@@ -210,11 +199,9 @@ val IbanTest by testSuite {
     test("Invoke should reject checksum failure") {
         assertFailure { Iban(INVALID_IBAN) }
             .isInstanceOf<IbanParseException.WrongChecksum>()
-            .given { failure ->
-                assertThat(failure)
-                    .prop(IbanParseException.WrongChecksum::input)
-                    .isEqualTo(INVALID_IBAN)
-                assertThat(failure.message).isEqualTo("Wrong check sum for $INVALID_IBAN")
+            .all {
+                prop(IbanParseException.WrongChecksum::input).isEqualTo(INVALID_IBAN)
+                hasMessage("Wrong check sum for $INVALID_IBAN")
             }
     }
 
@@ -243,11 +230,9 @@ val IbanTest by testSuite {
     }
 
     test("Compose should reject malformed country code") {
-        assertThat(
-                malformedKind {
-                    Iban.compose(countryCode = "potato", bban = VALID_IBAN.substring(4))
-                }
-            )
+        assertFailure { Iban.compose(countryCode = "potato", bban = VALID_IBAN.substring(4)) }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .prop(IbanParseException.Malformed::kind)
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_STRUCTURE)
     }
 

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -15,199 +15,214 @@
 */
 package nl.bijdorpstudio.kiban
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
-import assertk.tableOf
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+
+internal const val VALID_IBAN = "NL03ABNA0143267469"
+internal const val INVALID_IBAN = "NL13ABNA0143267469"
+
+/**
+ * One input per rejection kind the parser distinguishes, plus the valid IBAN. Shared by the tests
+ * that assert every entry point agrees on accept/reject and that nothing but [IbanParseException]
+ * escapes.
+ */
+private val rejectionKindInputs =
+    listOf(
+        "",
+        "Shenanigans!",
+        " $VALID_IBAN",
+        "$VALID_IBAN ",
+        "NL03",
+        "NLAB0143267469",
+        VALID_IBAN.replaceRange(6, 7, "_"),
+        "UU345678345543234",
+        VALID_IBAN + "0",
+        INVALID_IBAN,
+    )
+
+/**
+ * Asserts that [block] fails with an [IbanParseException] and returns the
+ * [IbanParseException.Malformed.Kind] it carries, or `null` if it was not a
+ * [IbanParseException.Malformed].
+ */
+private fun malformedKind(block: () -> Unit): IbanParseException.Malformed.Kind? {
+    var kind: IbanParseException.Malformed.Kind? = null
+    assertFailure { block() }
+        .isInstanceOf<IbanParseException>()
+        .given { failure -> kind = (failure as? IbanParseException.Malformed)?.kind }
+    return kind
+}
 
 /** Miscellaneous tests for the [Iban] class. */
-class IbanTest {
-    @Test
-    fun `Operator invoke should parse IBAN`() {
+val IbanTest by testSuite {
+    test("Operator invoke should parse IBAN") {
         // Called through the companion explicitly: inside the library module the private
         // constructor would win over invoke for an exact String argument.
         val iban = Iban.Companion.invoke(VALID_IBAN)
         assertThat(iban.plain).isEqualTo(VALID_IBAN)
     }
 
-    @Test
-    fun `Operator invoke should throw for invalid input`() {
-        assertFailsWith<IbanParseException.WrongChecksum> { Iban(INVALID_IBAN) }
+    test("Operator invoke should throw for invalid input") {
+        assertFailure { Iban(INVALID_IBAN) }.isInstanceOf<IbanParseException.WrongChecksum>()
     }
 
-    @Test
-    fun `toIban extension should parse IBAN`() {
+    test("toIban extension should parse IBAN") {
         val iban = VALID_IBAN.toIban()
         assertThat(iban.plain).isEqualTo(VALID_IBAN)
     }
 
-    @Test
-    fun `toIban extension should throw for invalid IBAN`() {
-        assertFailsWith<IbanParseException.WrongChecksum> { INVALID_IBAN.toIban() }
+    test("toIban extension should throw for invalid IBAN") {
+        assertFailure { INVALID_IBAN.toIban() }.isInstanceOf<IbanParseException.WrongChecksum>()
     }
 
-    @Test
-    fun `toIbanOrNull extension should parse IBAN`() {
+    test("toIbanOrNull extension should parse IBAN") {
         assertThat(VALID_IBAN.toIbanOrNull()?.plain).isEqualTo(VALID_IBAN)
     }
 
-    @Test
-    fun `toIbanOrNull extension should return null for invalid IBAN`() {
+    test("toIbanOrNull extension should return null for invalid IBAN") {
         assertThat(INVALID_IBAN.toIbanOrNull()).isNull()
     }
 
-    @Test
-    fun `isValidIban extension should return true for valid IBAN`() {
+    test("isValidIban extension should return true for valid IBAN") {
         assertThat(VALID_IBAN.isValidIban()).isTrue()
     }
 
-    @Test
-    fun `isValidIban extension should return false for invalid IBAN`() {
+    test("isValidIban extension should return false for invalid IBAN") {
         assertThat(INVALID_IBAN.isValidIban()).isFalse()
     }
 
-    @Test
-    fun `isValidIban and toIbanOrNull should agree with invoke for every rejection kind`() {
-        listOf(
-                "",
-                "Shenanigans!",
-                " $VALID_IBAN",
-                "$VALID_IBAN ",
-                "NL03",
-                "NLAB0143267469",
-                VALID_IBAN.replaceRange(6, 7, "_"),
-                "UU345678345543234",
-                VALID_IBAN + "0",
-                INVALID_IBAN,
-                VALID_IBAN,
-            )
-            .forEach { input ->
-                val expectedSuccess = runCatching { Iban(input) }.isSuccess
+    for (input in rejectionKindInputs + VALID_IBAN) {
+        test("isValidIban and toIbanOrNull should agree with invoke for '$input'") {
+            val expectedSuccess = runCatching { Iban(input) }.isSuccess
 
-                assertThat(input.isValidIban(), "isValidIban for '$input'")
-                    .isEqualTo(expectedSuccess)
-                assertThat(input.toIbanOrNull() != null, "toIbanOrNull for '$input'")
-                    .isEqualTo(expectedSuccess)
-            }
+            assertThat(input.isValidIban(), "isValidIban for '$input'").isEqualTo(expectedSuccess)
+            assertThat(input.toIbanOrNull() != null, "toIbanOrNull for '$input'")
+                .isEqualTo(expectedSuccess)
+        }
     }
 
-    @Test
-    fun `Valid IBAN should return country code`() {
+    test("Valid IBAN should return country code") {
         assertThat(Iban(VALID_IBAN).countryCode).isEqualTo("NL")
     }
 
-    @Test
-    fun `Valid IBAN should return check digits`() {
+    test("Valid IBAN should return check digits") {
         assertThat(Iban(VALID_IBAN).checkDigits).isEqualTo("03")
     }
 
-    @Test
-    fun `Invoke should accept toString output of valid IBAN`() {
+    test("Invoke should accept toString output of valid IBAN") {
         val original = Iban(VALID_IBAN)
         val copy = Iban(original.toString())
         assertThat(copy).isEqualTo(original)
     }
 
-    @Test
-    fun `Invoke should reject empty input`() {
+    test("Invoke should reject empty input") {
         assertThat(malformedKind { Iban("") }).isEqualTo(IbanParseException.Malformed.Kind.EMPTY)
     }
 
-    @Test
-    fun `Invoke should reject invalid input`() {
-        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("Shenanigans!") }
-
-        assertThat(failure.kind)
-            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
-        assertThat(failure.message)
-            .isEqualTo("Input begins or ends in an invalid character: Shenanigans!")
+    test("Invoke should reject invalid input") {
+        assertFailure { Iban("Shenanigans!") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .given { failure ->
+                assertThat(failure.kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+                assertThat(failure.message)
+                    .isEqualTo("Input begins or ends in an invalid character: Shenanigans!")
+            }
     }
 
-    @Test
-    fun `Invoke should reject leading whitespace`() {
-        val failure = assertFailsWith<IbanParseException.Malformed> { Iban(" $VALID_IBAN") }
-
-        assertThat(failure.kind)
-            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
-        assertThat(failure.message)
-            .isEqualTo("Input begins or ends in an invalid character:  $VALID_IBAN")
+    test("Invoke should reject leading whitespace") {
+        assertFailure { Iban(" $VALID_IBAN") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .given { failure ->
+                assertThat(failure.kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+                assertThat(failure.message)
+                    .isEqualTo("Input begins or ends in an invalid character:  $VALID_IBAN")
+            }
     }
 
-    @Test
-    fun `Invoke should reject trailing whitespace`() {
-        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("$VALID_IBAN ") }
-
-        assertThat(failure.kind)
-            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
-        assertThat(failure.message)
-            .isEqualTo("Input begins or ends in an invalid character: $VALID_IBAN ")
+    test("Invoke should reject trailing whitespace") {
+        assertFailure { Iban("$VALID_IBAN ") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .given { failure ->
+                assertThat(failure.kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+                assertThat(failure.message)
+                    .isEqualTo("Input begins or ends in an invalid character: $VALID_IBAN ")
+            }
     }
 
-    @Test
-    fun `Invoke should reject too short input`() {
-        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("NL03") }
-
-        assertThat(failure.kind).isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
-        assertThat(failure.message).isEqualTo("Length is too short to be an IBAN: NL03")
+    test("Invoke should reject too short input") {
+        assertFailure { Iban("NL03") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .given { failure ->
+                assertThat(failure.kind).isEqualTo(IbanParseException.Malformed.Kind.TOO_SHORT)
+                assertThat(failure.message).isEqualTo("Length is too short to be an IBAN: NL03")
+            }
     }
 
-    @Test
-    fun `Invoke should reject non numeric check digits`() {
-        val failure = assertFailsWith<IbanParseException.Malformed> { Iban("NLAB0143267469") }
-
-        assertThat(failure.kind)
-            .isEqualTo(IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS)
-        assertThat(failure.message)
-            .isEqualTo("Characters at index 2 and 3 not both numeric. NLAB0143267469")
+    test("Invoke should reject non numeric check digits") {
+        assertFailure { Iban("NLAB0143267469") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .given { failure ->
+                assertThat(failure.kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS)
+                assertThat(failure.message)
+                    .isEqualTo("Characters at index 2 and 3 not both numeric. NLAB0143267469")
+            }
     }
 
-    @Test
-    fun `Invoke should reject unsupported characters`() {
+    test("Invoke should reject unsupported characters") {
         val invalidCharacter = VALID_IBAN.replaceRange(6, 7, "_")
 
         assertThat(malformedKind { Iban(invalidCharacter) })
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
     }
 
-    @Test
-    fun `Invoke should reject unknown country code`() {
-        val failure =
-            assertFailsWith<IbanParseException.UnknownCountryCode> { Iban("UU345678345543234") }
-
-        assertThat(failure).prop(IbanParseException.UnknownCountryCode::countryCode).isEqualTo("UU")
-        assertThat(failure.message).isEqualTo("Unknown country code: UU")
+    test("Invoke should reject unknown country code") {
+        assertFailure { Iban("UU345678345543234") }
+            .isInstanceOf<IbanParseException.UnknownCountryCode>()
+            .given { failure ->
+                assertThat(failure)
+                    .prop(IbanParseException.UnknownCountryCode::countryCode)
+                    .isEqualTo("UU")
+                assertThat(failure.message).isEqualTo("Unknown country code: UU")
+            }
     }
 
-    @Test
-    fun `Invoke should reject wrong length`() {
+    test("Invoke should reject wrong length") {
         val tooLong = VALID_IBAN + "0"
 
-        val failure = assertFailsWith<IbanParseException.WrongLength> { Iban(tooLong) }
-
-        assertThat(failure).prop(IbanParseException.WrongLength::expectedLength).isEqualTo(18)
+        assertFailure { Iban(tooLong) }
+            .isInstanceOf<IbanParseException.WrongLength>()
+            .prop(IbanParseException.WrongLength::expectedLength)
+            .isEqualTo(18)
     }
 
-    @Test
-    fun `Invoke should reject checksum failure`() {
-        val failure = assertFailsWith<IbanParseException.WrongChecksum> { Iban(INVALID_IBAN) }
-
-        assertThat(failure).prop(IbanParseException.WrongChecksum::input).isEqualTo(INVALID_IBAN)
-        assertThat(failure.message).isEqualTo("Wrong check sum for $INVALID_IBAN")
+    test("Invoke should reject checksum failure") {
+        assertFailure { Iban(INVALID_IBAN) }
+            .isInstanceOf<IbanParseException.WrongChecksum>()
+            .given { failure ->
+                assertThat(failure)
+                    .prop(IbanParseException.WrongChecksum::input)
+                    .isEqualTo(INVALID_IBAN)
+                assertThat(failure.message).isEqualTo("Wrong check sum for $INVALID_IBAN")
+            }
     }
 
-    @Test
-    fun `Invoke failure should be an IllegalArgumentException`() {
-        assertFailsWith<IllegalArgumentException> { Iban(INVALID_IBAN) }
+    test("Invoke failure should be an IllegalArgumentException") {
+        assertFailure { Iban(INVALID_IBAN) }.isInstanceOf<IllegalArgumentException>()
     }
 
-    @Test
-    fun `Compose should handle correct input`() {
+    test("Compose should handle correct input") {
         val composed =
             Iban.compose(
                 countryCode = VALID_IBAN.substring(0, 2),
@@ -216,22 +231,18 @@ class IbanTest {
         assertThat(composed).isEqualTo(Iban(VALID_IBAN))
     }
 
-    @Test
-    fun `Compose should handle check digits of ten and higher`() {
+    test("Compose should handle check digits of ten and higher") {
         val composed = Iban.compose(countryCode = "BI", bban = "10000100010000332045181")
 
         assertThat(composed.plain).isEqualTo("BI4210000100010000332045181")
     }
 
-    @Test
-    fun `Compose should reject blank country code`() {
-        assertFailsWith<IbanParseException> {
-            Iban.compose(countryCode = "  ", bban = VALID_IBAN.substring(4))
-        }
+    test("Compose should reject blank country code") {
+        assertFailure { Iban.compose(countryCode = "  ", bban = VALID_IBAN.substring(4)) }
+            .isInstanceOf<IbanParseException>()
     }
 
-    @Test
-    fun `Compose should reject malformed country code`() {
+    test("Compose should reject malformed country code") {
         assertThat(
                 malformedKind {
                     Iban.compose(countryCode = "potato", bban = VALID_IBAN.substring(4))
@@ -240,22 +251,22 @@ class IbanTest {
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_STRUCTURE)
     }
 
-    @Test
-    fun `Compose should reject unknown country code`() {
-        assertFailsWith<IbanParseException.UnknownCountryCode> {
-            Iban.compose(countryCode = "XX", bban = VALID_IBAN.substring(4))
-        }
+    test("Compose should reject unknown country code") {
+        assertFailure { Iban.compose(countryCode = "XX", bban = VALID_IBAN.substring(4)) }
+            .isInstanceOf<IbanParseException.UnknownCountryCode>()
     }
 
-    @Test
-    fun `Compose should reject wrong length BBAN`() {
-        assertFailsWith<IbanParseException.WrongLength> {
-            Iban.compose(countryCode = VALID_IBAN.substring(0, 2), bban = VALID_IBAN.substring(5))
+    test("Compose should reject wrong length BBAN") {
+        assertFailure {
+            Iban.compose(
+                countryCode = VALID_IBAN.substring(0, 2),
+                bban = VALID_IBAN.substring(5),
+            )
         }
+            .isInstanceOf<IbanParseException.WrongLength>()
     }
 
-    @Test
-    fun `Equals contract should be satisfied`() {
+    test("Equals contract should be satisfied") {
         val x = Iban(VALID_IBAN)
         val y = Iban(VALID_IBAN)
         val z = Iban(VALID_IBAN)
@@ -268,44 +279,45 @@ class IbanTest {
         assertThat(x, "Equality is transitive").isEqualTo(z)
     }
 
-    @Test
-    fun `Add spaces should format IBAN correctly`() {
-        tableOf("input", "formatted")
-            .row("", "")
-            .row("12", "12")
-            .row("1 2", "12")
-            .row("1234", "1234")
-            .row("1 2 3 4", "1234")
-            .row("12345", "1234 5")
-            .row("1234 5", "1234 5")
-            .row("12345678", "1234 5678")
-            .row("1234 5678", "1234 5678")
-            .row("123456789", "1234 5678 9")
-            .row("1234 5678 9", "1234 5678 9")
-            .forAll { input, formatted ->
-                assertThat(Iban.addSpaces(Iban.toPlain(input))).isEqualTo(formatted)
-            }
+    for ((input, formatted) in
+        listOf(
+            "" to "",
+            "12" to "12",
+            "1 2" to "12",
+            "1234" to "1234",
+            "1 2 3 4" to "1234",
+            "12345" to "1234 5",
+            "1234 5" to "1234 5",
+            "12345678" to "1234 5678",
+            "1234 5678" to "1234 5678",
+            "123456789" to "1234 5678 9",
+            "1234 5678 9" to "1234 5678 9",
+        )) {
+        test("Add spaces should format '$input' as '$formatted'") {
+            assertThat(Iban.addSpaces(Iban.toPlain(input))).isEqualTo(formatted)
+        }
     }
 
-    @Test
-    fun `To plain should remove formatting from IBAN`() {
-        tableOf("input", "plain")
-            .row("", "")
-            .row("12", "12")
-            .row("1 2", "12")
-            .row("1234", "1234")
-            .row("1 2 3 4", "1234")
-            .row("12345", "12345")
-            .row("1234 5", "12345")
-            .row("12345678", "12345678")
-            .row("1234 5678", "12345678")
-            .row("123456789", "123456789")
-            .row("1234 5678 9", "123456789")
-            .forAll { input, plain -> assertThat(Iban.toPlain(input)).isEqualTo(plain) }
+    for ((input, plain) in
+        listOf(
+            "" to "",
+            "12" to "12",
+            "1 2" to "12",
+            "1234" to "1234",
+            "1 2 3 4" to "1234",
+            "12345" to "12345",
+            "1234 5" to "12345",
+            "12345678" to "12345678",
+            "1234 5678" to "12345678",
+            "123456789" to "123456789",
+            "1234 5678 9" to "123456789",
+        )) {
+        test("To plain should reduce '$input' to '$plain'") {
+            assertThat(Iban.toPlain(input)).isEqualTo(plain)
+        }
     }
 
-    @Test
-    fun `Lexical sort should order IBANs correctly`() {
+    test("Lexical sort should order IBANs correctly") {
         val expected =
             listOf(
                 Iban("DK3400000000000003"),
@@ -325,41 +337,21 @@ class IbanTest {
     // T3: for a representative set of invalid inputs across every rejection kind, invoke,
     // toIban and compose must only ever throw IbanParseException — nothing raw from Modulo97 or
     // the stdlib may escape. This is what makes @Throws sound on Kotlin/Native.
-    @Test
-    fun `Only IbanParseException escapes invoke and toIban for every rejection kind`() {
-        listOf(
-                "",
-                "Shenanigans!",
-                " $VALID_IBAN",
-                "$VALID_IBAN ",
-                "NL03",
-                "NLAB0143267469",
-                VALID_IBAN.replaceRange(6, 7, "_"),
-                "UU345678345543234",
-                VALID_IBAN + "0",
-                INVALID_IBAN,
-            )
-            .forEach { input ->
-                assertFailsWith<IbanParseException>("invoke($input)") { Iban(input) }
-                assertFailsWith<IbanParseException>("toIban($input)") { input.toIban() }
-            }
-    }
-
-    @Test
-    fun `Only IbanParseException escapes compose for every rejection kind`() {
-        assertFailsWith<IbanParseException> { Iban.compose("  ", VALID_IBAN.substring(4)) }
-        assertFailsWith<IbanParseException> { Iban.compose("potato", VALID_IBAN.substring(4)) }
-        assertFailsWith<IbanParseException> { Iban.compose("XX", VALID_IBAN.substring(4)) }
-        assertFailsWith<IbanParseException> {
-            Iban.compose(VALID_IBAN.substring(0, 2), VALID_IBAN.substring(5))
+    for (input in rejectionKindInputs) {
+        test("Only IbanParseException escapes invoke and toIban for '$input'") {
+            assertFailure { Iban(input) }.isInstanceOf<IbanParseException>()
+            assertFailure { input.toIban() }.isInstanceOf<IbanParseException>()
         }
     }
 
-    companion object {
-        internal const val VALID_IBAN = "NL03ABNA0143267469"
-        private const val INVALID_IBAN = "NL13ABNA0143267469"
-
-        private fun malformedKind(block: () -> Unit): IbanParseException.Malformed.Kind? =
-            (assertFailsWith<IbanParseException> { block() } as? IbanParseException.Malformed)?.kind
+    test("Only IbanParseException escapes compose for every rejection kind") {
+        assertFailure { Iban.compose("  ", VALID_IBAN.substring(4)) }
+            .isInstanceOf<IbanParseException>()
+        assertFailure { Iban.compose("potato", VALID_IBAN.substring(4)) }
+            .isInstanceOf<IbanParseException>()
+        assertFailure { Iban.compose("XX", VALID_IBAN.substring(4)) }
+            .isInstanceOf<IbanParseException>()
+        assertFailure { Iban.compose(VALID_IBAN.substring(0, 2), VALID_IBAN.substring(5)) }
+            .isInstanceOf<IbanParseException>()
     }
 }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/Modulo97Test.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/Modulo97Test.kt
@@ -15,94 +15,58 @@
 */
 package nl.bijdorpstudio.kiban
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isTrue
-import kotlin.test.Test
-import kotlin.test.assertFailsWith
+import de.infix.testBalloon.framework.core.testSuite
+
+private const val VALID_COUNTRY = "NL"
+private const val VALID_BBAN = "ABNA0417164300"
 
 /** Test suite for [Modulo97]. */
-class Modulo97Test {
-
-    @Test
-    fun `It should reject length 0`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("") }
+val Modulo97Test by testSuite {
+    // Inputs the checksum must reject outright: anything shorter than five characters, and
+    // anything holding a character outside the accepted alphabet.
+    for ((label, input) in
+        listOf(
+            "length 0" to "",
+            "length 1" to "M",
+            "length 2" to "MO",
+            "length 3" to "MO9",
+            "length 4" to "MO97",
+            "length 1 padded to 5" to "M    ",
+            "length 2 padded to 5" to "   MO",
+            "length 3 padded to 5" to "M O 9",
+            "length 4 padded to 5" to " MO97",
+            "invalid non-whitespace" to "TS00☠",
+            "invalid whitespace" to "MO97\tA",
+        )) {
+        test("It should reject $label") {
+            assertFailure { Modulo97.checksum(input) }.isInstanceOf<IllegalArgumentException>()
+        }
     }
 
-    @Test
-    fun `It should reject length 1`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("M") }
-    }
-
-    @Test
-    fun `It should reject length 2`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("MO") }
-    }
-
-    @Test
-    fun `It should reject length 3`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("MO9") }
-    }
-
-    @Test
-    fun `It should reject length 4`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("MO97") }
-    }
-
-    @Test
-    fun `It should reject length 1 padded to 5`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("M    ") }
-    }
-
-    @Test
-    fun `It should reject length 2 padded to 5`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("   MO") }
-    }
-
-    @Test
-    fun `It should reject length 3 padded to 5`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("M O 9") }
-    }
-
-    @Test
-    fun `It should reject length 4 padded to 5`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum(" MO97") }
-    }
-
-    @Test
-    fun `It should reject invalid non-whitespace`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("TS00☠") }
-    }
-
-    @Test
-    fun `It should reject invalid whitespace`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.checksum("MO97\tA") }
-    }
-
-    @Test
-    fun `It should calculate an expected checksum`() {
+    test("It should calculate an expected checksum") {
         assertThat(Modulo97.checksum("MO00T")).isEqualTo(83)
     }
 
-    @Test
-    fun `It should ignore case`() {
+    test("It should ignore case") {
         assertThat(Modulo97.checksum("MO00T")).isEqualTo(83)
         assertThat(Modulo97.checksum("mo00t")).isEqualTo(83)
     }
 
-    @Test
-    fun `It should calculate an expected check digits`() {
+    test("It should calculate an expected check digits") {
         assertThat(Modulo97.calculateCheckDigits("MO00T")).isEqualTo(15)
     }
 
-    @Test
-    fun `It should return 1 for a known correct checksum`() {
+    test("It should return 1 for a known correct checksum") {
         assertThat(Modulo97.checksum("MO15T")).isEqualTo(1)
     }
 
-    @Test
-    fun `It should verify a known correct checksum`() {
+    test("It should verify a known correct checksum") {
         assertThat(Modulo97.verifyCheckDigits("MO15T")).isTrue()
         for (i in 0 until 15) {
             val verifyResult = Modulo97.verifyCheckDigits("MO${i.toString().padStart(2, '0')}T")
@@ -114,24 +78,22 @@ class Modulo97Test {
         }
     }
 
-    @Test
-    fun `Should verify correct Iban`() {
-        val verifyResult = Modulo97.verifyCheckDigits(IbanTest.VALID_IBAN)
+    test("Should verify correct Iban") {
+        val verifyResult = Modulo97.verifyCheckDigits(VALID_IBAN)
         assertThat(verifyResult).isTrue()
     }
 
-    @Test
-    fun `It should refuse to calculate check digits if index 2 is not 0`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.calculateCheckDigits("MO10A") }
+    test("It should refuse to calculate check digits if index 2 is not 0") {
+        assertFailure { Modulo97.calculateCheckDigits("MO10A") }
+            .isInstanceOf<IllegalArgumentException>()
     }
 
-    @Test
-    fun `It should refuse to calculate check digits if index 3 is not 0`() {
-        assertFailsWith<IllegalArgumentException> { Modulo97.calculateCheckDigits("MO02A") }
+    test("It should refuse to calculate check digits if index 3 is not 0") {
+        assertFailure { Modulo97.calculateCheckDigits("MO02A") }
+            .isInstanceOf<IllegalArgumentException>()
     }
 
-    @Test
-    fun `Compose should handle IBAN valid input`() {
+    test("Compose should handle IBAN valid input") {
         val checkDigits =
             Modulo97.calculateCheckDigits(
                 countryCode = VALID_COUNTRY,
@@ -140,28 +102,27 @@ class Modulo97Test {
         assertThat(checkDigits).isEqualTo(91)
     }
 
-    @Test
-    fun `Compose should reject blank country code`() {
-        assertFailsWith<IllegalArgumentException> {
+    test("Compose should reject blank country code") {
+        assertFailure {
             Modulo97.calculateCheckDigits(
                 countryCode = "  ",
                 bban = VALID_BBAN,
             )
         }
+            .isInstanceOf<IllegalArgumentException>()
     }
 
-    @Test
-    fun `Compose should reject malformed country code`() {
-        assertFailsWith<IllegalArgumentException> {
+    test("Compose should reject malformed country code") {
+        assertFailure {
             Modulo97.calculateCheckDigits(
                 countryCode = "potato",
                 bban = VALID_BBAN,
             )
         }
+            .isInstanceOf<IllegalArgumentException>()
     }
 
-    @Test
-    fun `Compose should accept unknown country code`() {
+    test("Compose should accept unknown country code") {
         val checkDigits =
             Modulo97.calculateCheckDigits(
                 countryCode = "XX",
@@ -170,18 +131,12 @@ class Modulo97Test {
         assertThat(checkDigits).isEqualTo(72)
     }
 
-    @Test
-    fun `Compose should accept wrong length BBAN`() {
+    test("Compose should accept wrong length BBAN") {
         val checkDigits =
             Modulo97.calculateCheckDigits(
                 countryCode = VALID_COUNTRY,
                 bban = VALID_BBAN.substring(1),
             )
         assertThat(checkDigits).isEqualTo(50)
-    }
-
-    companion object {
-        private const val VALID_COUNTRY = "NL"
-        private const val VALID_BBAN = "ABNA0417164300"
     }
 }


### PR DESCRIPTION
Acts on the evaluation recorded in [`docs/82-testballoon-evaluation.md`](https://github.com/BijdorpStudio/kiban/blob/main/docs/82-testballoon-evaluation.md), which recommended this migration and scoped it.

## Why

The country table was folded into an assertk `Table1` and looped inside a handful of `@Test` methods, so all 111 countries collapsed into 3 reported cases. A registry update that broke one country failed one opaque test and stopped the loop — hiding both *which* country moved and the fact that the other 110 still passed. That report is the first thing a reviewer reads on the automated registry-sync pull requests.

## What changed

**Reporting.** Each country now registers as its own test, so the suite goes from **78 reported tests to 1,217** with no loss of coverage:

```
Length for Albania should return correct value[jvm]
Length for Algeria should return correct value[jvm]
Compose should round trip Albania[jvm]
Should extract bank identifier for Albania[jvm]
…
```

The `Table1`-folding boilerplate and the cross-file `CountryCodesParameterizedTest.countriesTestDataTable.forAll { … }` companion references are gone; the sorted country list is now a plain top-level `internal val countriesTestData`. All 12 `forAll` call sites across the four files were replaced in one commit, as the evaluation advised. The local `tableOf` tables in `IbanTest` (`addSpaces`, `toPlain`) and the labelled `forEach` rejection-kind loops became per-input tests too, which turns their assertion labels into test names.

**Declaration only — assertions are untouched.** assertk stays exactly as it was. The ~40 `assertFailsWith<T> { … }` call sites became `assertFailure { … }.isInstanceOf<T>()`, chaining `.prop(…)` or assertk's `all { }` + `hasMessage` where the old code inspected the caught exception. `kotlin-test` is dropped from `commonTest` entirely.

**The one `@Ignore` came back to life on the JVM.** `Known country codes should not be editable` carried `@Ignore // Fails on Kotlin native`, but `@Ignore` is all-or-nothing, so it ran on *no* target — the JVM was losing the coverage for a Native-only problem. `testConfig` is an ordinary value, so the condition can be an expression:

```kotlin
testConfig = if (testPlatform.type == TestPlatform.Type.Jvm) TestConfig else TestConfig.disable(),
```

The failure it was hiding, confirmed by running it on linuxX64:

```
expected to be instance of:<class kotlin.UnsupportedOperationException>
                but had class:<class kotlin.ClassCastException>
```

Only the JVM erases `Collection` and `MutableCollection` to the same type, so only there is the cast a runtime no-op that lets `add` reach the fixed-size list from `asList()` and be rejected. Elsewhere the cast is checked and fails first. The collection is immutable on every target; the exception type is what differs. `jvmTest` now reports **0 skipped**; the non-JVM targets still report 1.

**Version choice.** TestBalloon `1.1.0-RC` (released 2026-08-12) rather than the stable `1.0.1-K2.4.0`. It is the first *unified* release — one artifact set that auto-adapts to the Kotlin compiler in use (2.2.0 … 2.5.0-dev), instead of 1.0.x's one-artifact-set-per-Kotlin-version scheme, which would have made every Kotlin bump a coupled TestBalloon bump. That coupling was the one durable objection the evaluation raised. 1.1.0-RC is binary compatible with 1.0.1, so moving to 1.1.0 when it ships is a one-line catalog change; the reasoning is recorded as a comment on the version.

**Constraints from the issue, checked.**

* *Published artifact stays dependency-free* — generated POMs for `jvm`, `linuxX64` and `kotlinMultiplatform` each declare exactly one dependency, `kotlin-stdlib`. No TestBalloon, assertk or JUnit leaked.
* *`apiCheck` clean* — passes unchanged; `library/api/` is untouched in this diff, so no `apiDump` was needed.
* *No new Gradle test tasks* — TestBalloon plugs into the existing KMP test tasks, so `.github/workflows/gradle.yml` needed no edits.
* *Android host tests* — `junit:junit` added to `androidHostTest`, which TestBalloon's Android host-side runner requires.
* *`pluginManagement`* — the issue expected this to need adjusting since TestBalloon is not on the Gradle Plugin Portal, but `settings.gradle.kts` already lists `mavenCentral()` there, so no change was necessary.
* *Nested-suite encoding gotcha* (§6 of the evaluation) — avoided by keeping every suite flat and top-level.

## Verification

Run in this sandbox, all passing:

| Command | Result |
|---|---|
| `./gradlew :library:jvmTest` | 1,217 tests, 0 failures, 0 skipped |
| `./gradlew :library:linuxX64Test` | 1,217 tests, 0 failures, 1 skipped (the JVM-only immutability test) |
| `./gradlew apiCheck` | passes, dump unchanged |
| `./gradlew ktfmtCheck` | passes |
| `compileTestKotlinJs`, `compileTestKotlinWasmJs`, `compileTestKotlinLinuxArm64`, `compileTestKotlinMingwX64` | all compile |
| `generatePomFileFor{Jvm,LinuxX64,KotlinMultiplatform}Publication` | `kotlin-stdlib` only |

**Not verified here**, per `CLAUDE.md` — no Xcode toolchain, no Android SDK, and `:kotlinNpmInstall` cannot reach the npm registry from this sandbox: the Apple targets, `:library:testAndroidHostTest`, and the JS/wasmJs *runtimes* (their test compilation does succeed, exercising the compiler plugin's JS and Wasm codegen). All three were covered by CI on the first push — Android, `js-test`, `wasm-js-test` and all four Apple legs passed, along with `api-check` on macOS, which builds the klibs for every Apple target.

One measurement, since it is the obvious question: `:library:jvmTest --rerun-tasks` on a warm daemon goes from a ~3.0s median to ~4.75s. That is per-test bookkeeping for 1,217 reported tests instead of 78 — the same assertions run either way. (CI job durations are *not* a fair comparison: PR branches run `cache-read-only`, so `ktfmt-check`, which runs no tests at all, also went 12s→52s on the first push.)

**Still open:** IDE gutter-run via the TestBalloon IntelliJ plugin, which issue #115 lists as a check. It needs a real IDE and could not be verified from a headless container.

Closes #115