### PR TITLE
Scope the GITHUB_TOKEN in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,14 @@ name: Publish
 on:
   release:
     types: [released, prereleased]
+
+# Least privilege for every job in this workflow. Without this the GITHUB_TOKEN falls back to the
+# repository default, which is read-write for repositories created before February 2023 — and the
+# 'publish' job runs with the Maven Central and GPG signing secrets in scope. The 'docs' job
+# widens this for its Pages deployment; nothing else here needs more than read.
+permissions:
+  contents: read
+
 jobs:
   # Run the full check matrix (tests on every target plus apiCheck) before publishing anything.
   test:


### PR DESCRIPTION
Fixes the two CodeQL `actions/missing-workflow-permissions` alerts, anchored at `publish.yml` **lines 10 and 15**.

## The finding

`publish.yml` was the only workflow with no root `permissions:` block, and two of its three jobs set none at any level, so both fell back to the repository default — read-write for repositories created before February 2023:

| Job | Alert anchor | Permissions before |
|---|---|---|
| `test` | line 10 (`name: Check`) | none |
| `publish` | line 15 (`name: Release build and publish`) | none |
| `docs` | — | `contents: read`, `pages: write`, `id-token: write` |

`publish` is the job that matters most here: it runs with `MAVEN_CENTRAL_USERNAME`/`PASSWORD`, `SIGNING_*` and `GPG_KEY_CONTENTS` in scope.

## The change

One root block, which is what the rule recommends — it "is applied to all jobs in the workflow that do not have their own permissions key", so it clears both alerts:

```yaml
permissions:
  contents: read
```

`docs` keeps its own wider override for the Pages deployment. Nothing else needs more than read:

* `publish` authenticates to Maven Central through secrets, not the `GITHUB_TOKEN`.
* `test` calls `gradle.yml`, which already declares `contents: read`. A called workflow cannot exceed its caller, so the two stay consistent.

## Verification

Audited every workflow and every job. All four workflows now have a root block, and each job is covered by either the root or its own:

```
gradle.yml               root=True    build→root   ci→root
ios-interop-verify.yml   root=True    verify→root
publish.yml              root=True    test→root    publish→root   docs→job
registry-sync.yml        root=True    sync→root

workflows with no permissions coverage: none
```

`publish.yml` still parses as valid YAML. The workflow only triggers on `release`, so it cannot be exercised by this PR — the change is confined to the `permissions` key and touches no job logic, and `gradle.yml` running on this PR covers that the reusable-workflow contract is unaffected.

## Note on how this was diagnosed

This environment's token lacks the `security_events` scope, so `/code-scanning/alerts` returns `403` (plain repo endpoints return `200`) and the alerts could not be read directly. The two unscoped jobs were identified by auditing the workflow sources against the rule, and the line numbers were confirmed afterwards against the alerts.