### PR TITLE
Stop listing every passing test in the CI job summary

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -126,9 +126,12 @@ jobs:
         annotate_only: true
         detailed_summary: true
         group_suite: true
-        # The per-country listing is the whole reason this is worth rendering on a
-        # passing run; failures alone are already visible in the Gradle log.
-        include_passed: true
+        # Counts on green, the grouped failure listing on red. Listing all 1,217
+        # passing tests here as well was tried and reverted: nine test jobs each
+        # rendering the full per-country table buried the two numbers anyone
+        # opens a summary for. The full listing is still a download away in the
+        # 'test-results-*' artifact.
+        include_passed: false
         # The Gradle step has already failed the job by this point. Failing again
         # here would only replace a diagnosable error with this action's own.
         fail_on_failure: false


### PR DESCRIPTION
Follow-up to #131, which overshot. It set `include_passed: true` on the per-job reporter so a green run would show the per-country listing #115 made possible — but that is 1,217 rows on each of nine test jobs, and it buries the counts and the failure list that are the reason to open a summary at all.

One line, `include_passed: true` → `false` on the `Report test results` step. The `ci` roll-up was already configured this way and is unchanged.

## What each summary shows now

| | before | after |
|---|---|---|
| green run | 1,217-row table per job | counts only — `1217 tests, 1217 passed, 0 failed, 0 skipped` |
| red run | failures buried under the passing rows | counts + the failing tests, grouped by suite |

Failure annotations on the run are unaffected — those never included passing tests (`annotate_notice` is off by default). The full per-test listing is still a download away in the `test-results-*` artifact, which #131 made upload on green runs too.

This keeps the acceptance bar #129 actually set — "at minimum per-target test counts" on green, failing test names on red — and drops only the per-country listing on top of it.

## Verification

YAML parses. No Kotlin touched, so `jvmTest` / `apiCheck` / `ktfmtCheck` are unaffected by the diff; the rendered summary is only observable on this PR's own Actions run.


---
_Generated by [Claude Code](https://claude.ai/code/session_018QeR9RoqrZ7P3J7XVQWeAs)_