### PR TITLE
Reject non-ASCII digits/letters in IBAN validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 0.6.0 (unreleased)
 
+**Breaking changes**
+
+* IBAN validation is now ASCII-only (#136). `Iban.validate` used `Char.isDigit()` and
+  `Char.isLetterOrDigit()`, and `Modulo97.checksum` used `Char.isDigit()` — all Unicode-aware on
+  every platform, as is `String.toLong`, which the checksum folds its buffer through. The effect was
+  that `Iban("NL９１ABNA0417164300")` (fullwidth digits) parsed successfully and produced an `Iban`
+  whose `plain` held non-ASCII characters, violating the class invariant and the documented
+  `[A-Za-z0-9 ]` character set. ISO 13616 defines the IBAN character set as ASCII `A-Z0-9`, so such
+  input is now rejected: `Malformed(NON_NUMERIC_CHECK_DIGITS)` for non-ASCII check digits,
+  `Malformed(INVALID_BOUNDARY_CHARACTER)` at the ends of the input and `Malformed(INVALID_CHARACTER)`
+  elsewhere. Rejecting rather than normalizing is deliberate — input-layer concerns like fullwidth
+  IME digits belong to the caller (NFKC before parsing), silently rewriting a bank account identifier
+  masks upstream data corruption, and any normalization line drawn here would become frozen contract
+  surface at 1.0. An opt-in normalizer stays possible later as an additive change; going lenient
+  first and strict later would not.
+
+* A known country code written in the wrong case is now reported as
+  `Malformed(NON_UPPER_CASE_COUNTRY_CODE)` instead of `UnknownCountryCode` (#136). Lower case input
+  such as `"nl91abna0417164300"` was already rejected and stays rejected (`java-iban` parity), but
+  the old rejection blamed the country rather than the case: `NL` is a known country code, `nl` is
+  the same country code miswritten. `NON_UPPER_CASE_COUNTRY_CODE` is a new `Malformed.Kind` entry,
+  so `when` statements over `Malformed.kind` that were exhaustive will need a branch for it. An
+  unknown country code that also happens to be lower case is still an `UnknownCountryCode`.
+
 **Documentation**
 
 * Cleaned up KDoc inherited from `java-iban` (#108). The `Iban` class documentation had its

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Parsing is strict: invalid input throws a typed `IbanParseException`, so you don
 `Result` for the common case. The exception-free `toIbanOrNull()` and `isValidIban()` are there for
 when you want to check input without paying for a stack trace.
 
+Input must be ASCII. ISO 13616 defines the IBAN character set as `A-Z0-9`, so upper case ASCII
+letters, ASCII digits and (ASCII 0x20) spaces are all that parse; non-ASCII look-alikes such as
+fullwidth `９` or Arabic-Indic `٩` digits are rejected rather than normalized, because silently
+rewriting a bank account identifier hides upstream data corruption. NFKC-normalize user input before
+parsing if your input layer can produce them.
+
 ``` kotlin
     // The primary entry point. Throws IbanParseException on invalid input.
     val iban: Iban = Iban( "NL91ABNA0417164300" )

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -57,6 +57,7 @@ public final class nl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind : ja
 	public static final field INVALID_CHARACTER Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
 	public static final field INVALID_STRUCTURE Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
 	public static final field NON_NUMERIC_CHECK_DIGITS Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
+	public static final field NON_UPPER_CASE_COUNTRY_CODE Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
 	public static final field TOO_SHORT Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -54,6 +54,7 @@ sealed class nl.bijdorpstudio.kiban/IbanParseException : kotlin/IllegalArgumentE
             enum entry INVALID_CHARACTER // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.INVALID_CHARACTER|null[0]
             enum entry INVALID_STRUCTURE // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.INVALID_STRUCTURE|null[0]
             enum entry NON_NUMERIC_CHECK_DIGITS // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS|null[0]
+            enum entry NON_UPPER_CASE_COUNTRY_CODE // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.NON_UPPER_CASE_COUNTRY_CODE|null[0]
             enum entry TOO_SHORT // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.TOO_SHORT|null[0]
 
             final val entries // nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind.entries|#static{}entries[0]

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -241,15 +241,25 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         }
 
         /**
-         * Whether the given country code is a known IBAN country code that was written in the wrong
-         * case. Such input stays rejected — kiban rejects rather than normalizes — but it deserves
-         * a better diagnosis than "unknown country code", because the country is known.
+         * Whether the given two-character country code is a known IBAN country code that was
+         * written in the wrong case. Such input stays rejected — kiban rejects rather than
+         * normalizes — but it deserves a better diagnosis than "unknown country code", because the
+         * country is known.
+         *
+         * Only called once the code has already failed the [CountryCodes.getLength] lookup, so both
+         * early returns keep a doomed input from paying for a second binary search.
          */
-        private fun isKnownCountryCodeInWrongCase(countryCode: String): Boolean =
-            countryCode.all { it in 'A'..'Z' || it in 'a'..'z' } &&
-                // Safe to uppercase: every character is known to be an ASCII letter, so this
-                // cannot produce a locale-dependent or length-changing result.
-                CountryCodes.getLength(countryCode.uppercase()) != null
+        private fun isKnownCountryCodeInWrongCase(countryCode: String): Boolean {
+            val first: Char = countryCode[0]
+            val second: Char = countryCode[1]
+            if (!first.isAsciiLetter() || !second.isAsciiLetter()) return false
+            // An all-upper-case code that failed the lookup is genuinely unknown: upper-casing it
+            // cannot change the outcome.
+            if (!first.isAsciiLowerCase() && !second.isAsciiLowerCase()) return false
+            return CountryCodes.getLength(
+                charArrayOf(first.uppercaseAscii(), second.uppercaseAscii()).concatToString()
+            ) != null
+        }
 
         /**
          * Removes any spaces contained in the String thereby converting the input into a plain IBAN
@@ -301,14 +311,37 @@ fun String.toIbanOrNull(): Iban? =
 fun String.isValidIban(): Boolean = Iban.validate(this) == null
 
 /**
+ * Bit 5 of an ASCII letter is its case bit: setting it maps `A`-`Z` onto `a`-`z` and clearing it
+ * maps them back. Testing a letter of either case is therefore one range check rather than two, and
+ * upper-casing one is a single mask rather than a trip through the Unicode case tables that
+ * [Char.uppercaseChar] consults.
+ */
+private const val ASCII_CASE_BIT = 0x20
+
+/**
  * Whether this is an ASCII digit. Deliberately not [Char.isDigit], which is Unicode-aware on every
  * platform and accepts fullwidth (`９`), Arabic-Indic (`٩`) and other non-ASCII digits.
  */
 private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
 
 /**
+ * Whether this is an ASCII letter of either case. Deliberately not [Char.isLetter], for the same
+ * reason as [isAsciiDigit]: folding the case first keeps this to a single range check, and folding
+ * a non-ASCII character can only move it further outside `a`-`z`.
+ */
+private fun Char.isAsciiLetter(): Boolean = (code or ASCII_CASE_BIT).toChar() in 'a'..'z'
+
+/** Whether this is a lower case ASCII letter. */
+private fun Char.isAsciiLowerCase(): Boolean = this in 'a'..'z'
+
+/**
+ * Upper-cases an ASCII letter by clearing its case bit. The receiver must already be one — every
+ * other character comes back mangled, not unchanged.
+ */
+private fun Char.uppercaseAscii(): Char = (code and ASCII_CASE_BIT.inv()).toChar()
+
+/**
  * Whether this is an ASCII letter or digit, the character set ISO 13616 allows in an IBAN.
  * Deliberately not [Char.isLetterOrDigit], for the same reason as [isAsciiDigit].
  */
-private fun Char.isAsciiLetterOrDigit(): Boolean =
-    isAsciiDigit() || this in 'A'..'Z' || this in 'a'..'z'
+private fun Char.isAsciiLetterOrDigit(): Boolean = isAsciiDigit() || isAsciiLetter()

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -126,6 +126,10 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         /**
          * Parses the given string into an IBAN object and confirms the check digits.
          *
+         * Input must be ASCII: ISO 13616 defines the IBAN character set as `A-Z0-9`, so non-ASCII
+         * look-alikes such as fullwidth digits are rejected rather than normalized. Normalize
+         * (NFKC) user input before parsing if your input layer can produce them.
+         *
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with
          *   (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
          * @return the parsed and validated IBAN object.
@@ -165,7 +169,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
             if (input.isEmpty()) {
                 return Rejection.Malformed("", Kind.EMPTY)
             }
-            if (!input.first().isLetterOrDigit() || !input.last().isLetterOrDigit()) {
+            if (!input.first().isAsciiLetterOrDigit() || !input.last().isAsciiLetterOrDigit()) {
                 return Rejection.Malformed(
                     toPlain(input),
                     Kind.INVALID_BOUNDARY_CHARACTER,
@@ -176,13 +180,17 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
             if (value.length < SHORTEST_POSSIBLE_IBAN) {
                 return Rejection.Malformed(value, Kind.TOO_SHORT)
             }
-            if (!(value[2].isDigit() && value[3].isDigit())) {
+            if (!(value[2].isAsciiDigit() && value[3].isAsciiDigit())) {
                 return Rejection.Malformed(value, Kind.NON_NUMERIC_CHECK_DIGITS)
             }
             val countryCode: String = value.substring(0, 2)
             val expectedLength: Int =
                 CountryCodes.getLength(countryCode)
-                    ?: return Rejection.UnknownCountryCode(value, countryCode)
+                    ?: return if (isKnownCountryCodeInWrongCase(countryCode)) {
+                        Rejection.Malformed(value, Kind.NON_UPPER_CASE_COUNTRY_CODE)
+                    } else {
+                        Rejection.UnknownCountryCode(value, countryCode)
+                    }
             if (expectedLength != value.length) {
                 return Rejection.WrongLength(value, expectedLength, value.length)
             }
@@ -233,6 +241,17 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         }
 
         /**
+         * Whether the given country code is a known IBAN country code that was written in the wrong
+         * case. Such input stays rejected — kiban rejects rather than normalizes — but it deserves
+         * a better diagnosis than "unknown country code", because the country is known.
+         */
+        private fun isKnownCountryCodeInWrongCase(countryCode: String): Boolean =
+            countryCode.all { it in 'A'..'Z' || it in 'a'..'z' } &&
+                // Safe to uppercase: every character is known to be an ASCII letter, so this
+                // cannot produce a locale-dependent or length-changing result.
+                CountryCodes.getLength(countryCode.uppercase()) != null
+
+        /**
          * Removes any spaces contained in the String thereby converting the input into a plain IBAN
          *
          * @param input possibly pretty printed IBAN
@@ -280,3 +299,16 @@ fun String.toIbanOrNull(): Iban? =
 
 /** Returns whether the given string is a valid IBAN. */
 fun String.isValidIban(): Boolean = Iban.validate(this) == null
+
+/**
+ * Whether this is an ASCII digit. Deliberately not [Char.isDigit], which is Unicode-aware on every
+ * platform and accepts fullwidth (`９`), Arabic-Indic (`٩`) and other non-ASCII digits.
+ */
+private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
+
+/**
+ * Whether this is an ASCII letter or digit, the character set ISO 13616 allows in an IBAN.
+ * Deliberately not [Char.isLetterOrDigit], for the same reason as [isAsciiDigit].
+ */
+private fun Char.isAsciiLetterOrDigit(): Boolean =
+    isAsciiDigit() || this in 'A'..'Z' || this in 'a'..'z'

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -50,10 +50,16 @@ sealed class IbanParseException(
             /** The input is shorter than [Iban.SHORTEST_POSSIBLE_IBAN]. */
             TOO_SHORT,
 
-            /** The characters at index 2 and 3 are not both numeric. */
+            /** The characters at index 2 and 3 are not both ASCII digits. */
             NON_NUMERIC_CHECK_DIGITS,
 
-            /** The input contains a character outside the range `[A-Za-z0-9 ]`. */
+            /**
+             * The country code is a known IBAN country code, but is not written in upper case.
+             * IBANs are upper case by definition, and kiban rejects rather than normalizes.
+             */
+            NON_UPPER_CASE_COUNTRY_CODE,
+
+            /** The input contains a character outside the ASCII range `[A-Za-z0-9 ]`. */
             INVALID_CHARACTER,
 
             /**
@@ -131,6 +137,8 @@ internal sealed class Rejection(val input: String) {
                 "Length is too short to be an IBAN: $input"
             IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS ->
                 "Characters at index 2 and 3 not both numeric. $input"
+            IbanParseException.Malformed.Kind.NON_UPPER_CASE_COUNTRY_CODE ->
+                "Country code is not upper case: ${input.take(2)}. $input"
             IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER,
             IbanParseException.Malformed.Kind.INVALID_CHARACTER,
             IbanParseException.Malformed.Kind.INVALID_STRUCTURE ->

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Modulo97.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Modulo97.kt
@@ -21,9 +21,11 @@ object Modulo97 {
     /**
      * Calculates the raw MOD97 checksum for a given input.
      *
-     * The input is allowed to contain space characters. Any character outside the range `[A-Za-z0-9
-     * ]` will cause an [IllegalArgumentException] to be thrown. This method allocates a temporary
-     * buffer of twice the input length, so it will fail for unreasonably large inputs.
+     * The input is allowed to contain space characters. Any character outside the ASCII range
+     * `[A-Za-z0-9 ]` will cause an [IllegalArgumentException] to be thrown; non-ASCII digits such
+     * as fullwidth `９` or Arabic-Indic `٩` are rejected rather than normalized. This method
+     * allocates a temporary buffer of twice the input length, so it will fail for unreasonably
+     * large inputs.
      *
      * It is expected but not enforced that the characters at index 2 and 3 are numeric. If the
      * existing check digits are `00` then this method will return the value that, after subtracting
@@ -109,7 +111,7 @@ object Modulo97 {
      * Copies `src[srcPos...srcLen)` into `dest[destPos)` while applying character to numeric
      * transformation and skipping over space (ASCII 0x20) characters.
      *
-     * @param src the data to begin copying, must contain only characters `[A-Za-z0-9 ]`.
+     * @param src the data to begin copying, must contain only ASCII characters `[A-Za-z0-9 ]`.
      * @param srcPos the index in `src` to begin transforming (inclusive).
      * @param srcLen the number of characters starting from `srcPos` to transform.
      * @param dest the buffer to write transformed characters into.
@@ -132,7 +134,10 @@ object Modulo97 {
         for (i in srcPos..<srcLen) {
             val c = src[i]
             when {
-                c.isDigit() -> {
+                // Deliberately not Char.isDigit(): that is Unicode-aware and would accept
+                // fullwidth or Arabic-Indic digits, which are not part of the ISO 13616
+                // character set. See Iban.validate for the same reasoning.
+                c in '0'..'9' -> {
                     dest[offset++] = c
                 }
 

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -31,6 +31,12 @@ import de.infix.testBalloon.framework.core.testSuite
 internal const val VALID_IBAN = "NL03ABNA0143267469"
 internal const val INVALID_IBAN = "NL13ABNA0143267469"
 
+/** [VALID_IBAN] with its check digits written as fullwidth (U+FF10..U+FF19) digits. */
+private val FULLWIDTH_CHECK_DIGITS = VALID_IBAN.replaceRange(2, 4, "０３")
+
+/** [VALID_IBAN] with one BBAN digit written as a fullwidth digit. */
+private val FULLWIDTH_DIGIT_IN_BBAN = VALID_IBAN.replaceRange(8, 9, "０")
+
 /**
  * One input per rejection kind the parser distinguishes, plus the valid IBAN. Shared by the tests
  * that assert every entry point agrees on accept/reject and that nothing but [IbanParseException]
@@ -48,6 +54,9 @@ private val rejectionKindInputs =
         "UU345678345543234",
         VALID_IBAN + "0",
         INVALID_IBAN,
+        VALID_IBAN.lowercase(),
+        FULLWIDTH_CHECK_DIGITS,
+        FULLWIDTH_DIGIT_IN_BBAN,
     )
 
 /** Miscellaneous tests for the [Iban] class. */
@@ -176,6 +185,64 @@ val IbanTest by testSuite {
             .isInstanceOf<IbanParseException.Malformed>()
             .prop(IbanParseException.Malformed::kind)
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+    }
+
+    test("Invoke should reject fullwidth check digits") {
+        assertFailure { Iban(FULLWIDTH_CHECK_DIGITS) }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .prop(IbanParseException.Malformed::kind)
+            .isEqualTo(IbanParseException.Malformed.Kind.NON_NUMERIC_CHECK_DIGITS)
+    }
+
+    for ((label, replacement) in
+        listOf(
+            "fullwidth" to "０",
+            "Arabic-Indic" to "٠",
+            "Devanagari" to "०",
+        )) {
+        test("Invoke should reject $label digits in the BBAN") {
+            assertFailure { Iban(VALID_IBAN.replaceRange(8, 9, replacement)) }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+        }
+    }
+
+    for ((label, replacement) in
+        listOf(
+            "fullwidth letter" to "Ｎ",
+            "Cyrillic look-alike" to "А",
+        )) {
+        test("Invoke should reject a leading non-ASCII $label") {
+            assertFailure { Iban(VALID_IBAN.replaceRange(0, 1, replacement)) }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+        }
+    }
+
+    test("Invoke should reject lower case input naming the case, not the country") {
+        assertFailure { Iban(VALID_IBAN.lowercase()) }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .all {
+                prop(IbanParseException.Malformed::kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.NON_UPPER_CASE_COUNTRY_CODE)
+                hasMessage("Country code is not upper case: nl. ${VALID_IBAN.lowercase()}")
+            }
+    }
+
+    test("Invoke should reject a mixed case country code") {
+        assertFailure { Iban(VALID_IBAN.replaceRange(1, 2, "l")) }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .prop(IbanParseException.Malformed::kind)
+            .isEqualTo(IbanParseException.Malformed.Kind.NON_UPPER_CASE_COUNTRY_CODE)
+    }
+
+    test("Invoke should still report an unknown country code that is lower case as unknown") {
+        assertFailure { Iban("uu345678345543234") }
+            .isInstanceOf<IbanParseException.UnknownCountryCode>()
+            .prop(IbanParseException.UnknownCountryCode::countryCode)
+            .isEqualTo("uu")
     }
 
     test("Invoke should reject unknown country code") {

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -187,6 +187,17 @@ val IbanTest by testSuite {
             .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
     }
 
+    // The ASCII letter test folds the case bit before comparing, so the characters that sit
+    // immediately either side of 'A'-'Z' and 'a'-'z' are where a mis-stated range would show up.
+    for (punctuation in listOf('@', '[', '`', '{', '/', ':')) {
+        test("Invoke should reject '$punctuation', adjacent to the ASCII letter range") {
+            assertFailure { Iban(VALID_IBAN.replaceRange(6, 7, punctuation.toString())) }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+        }
+    }
+
     test("Invoke should reject fullwidth check digits") {
         assertFailure { Iban(FULLWIDTH_CHECK_DIGITS) }
             .isInstanceOf<IbanParseException.Malformed>()

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/Modulo97Test.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/Modulo97Test.kt
@@ -43,6 +43,11 @@ val Modulo97Test by testSuite {
             "length 4 padded to 5" to " MO97",
             "invalid non-whitespace" to "TS00☠",
             "invalid whitespace" to "MO97\tA",
+            // ISO 13616 is ASCII-only, but Char.isDigit() is Unicode-aware: these used to be
+            // accepted and folded into the checksum as if they were ASCII digits.
+            "fullwidth digits" to "MO００T",
+            "Arabic-Indic digits" to "MO٠٠T",
+            "Devanagari digits" to "MO००T",
         )) {
         test("It should reject $label") {
             assertFailure { Modulo97.checksum(input) }.isInstanceOf<IllegalArgumentException>()


### PR DESCRIPTION
## What

`Iban.Companion.validate` used `Char.isDigit()` / `Char.isLetterOrDigit()` and `Modulo97.transform` used `Char.isDigit()` — all Unicode-aware on every platform, as is the `String.toLong` the checksum folds its transformed buffer through. `Iban("NL９１ABNA0417164300")` (fullwidth digits) therefore parsed successfully and produced an `Iban` whose `plain` held non-ASCII characters, violating the class invariant and the KDoc claim that the valid character set is `[A-Za-z0-9 ]`.

ISO 13616 defines the IBAN character set as ASCII `A-Z0-9`, so this rejects such input rather than normalizing it, per the decision recorded in the issue: input-layer concerns like fullwidth IME digits belong to the caller (NFKC before parsing), silently rewriting a bank account identifier masks upstream data corruption, and any normalization line drawn here would become frozen contract surface at 1.0. An opt-in normalizer stays possible later as an additive change; lenient-then-strict would not.

## Changes

- **`Modulo97.transform`**: `c in '0'..'9'` instead of `c.isDigit()`. The ASCII letter ranges were already correct. This also closes the `String.toLong` path, since the buffer now only ever holds ASCII digits.
- **`Iban.validate`**: the boundary test and the check-digit test are ASCII range checks (`isAsciiLetterOrDigit` / `isAsciiDigit`, private helpers with a note on why `Char.isDigit` is not used), so rejection fires with the right diagnosis:
  - non-ASCII check digits → `Malformed(NON_NUMERIC_CHECK_DIGITS)`
  - non-ASCII at either end of the input → `Malformed(INVALID_BOUNDARY_CHARACTER)`
  - non-ASCII elsewhere → `Malformed(INVALID_CHARACTER)`, via the existing `Modulo97` failure path
- **Wrongly cased country codes** (the "while in this area" item): `"nl91abna0417164300"` was rejected as `UnknownCountryCode("nl")`, which blames the country when the country is known and only the case is wrong. It stays rejected (java-iban parity) but now as `Malformed(NON_UPPER_CASE_COUNTRY_CODE)` — a new `Malformed.Kind` entry — with the message `Country code is not upper case: nl. nl91abna0417164300`. Mixed case (`"Nl03…"`) is covered by the same branch. An unknown country code that also happens to be lower case (`"uu345678345543234"`) is still an `UnknownCountryCode`.
- **README**: a paragraph in the Use section stating that input must be ASCII and that callers should NFKC-normalize user input before parsing if their input layer can produce look-alikes.
- **CHANGELOG**: a Breaking changes section under 0.6.0 (unreleased) covering both behaviour changes, including the note that `when` statements over `Malformed.kind` that were exhaustive need a branch for the new entry.

## API surface

The only public change is the additive `Malformed.Kind.NON_UPPER_CASE_COUNTRY_CODE` entry. `./gradlew apiDump` was run and both dumps (`library/api/jvm/library.api`, `library/api/library.klib.api`) are committed — one added line each.

## Tests

- `Modulo97Test`: fullwidth, Arabic-Indic and Devanagari digits added to the reject-outright table.
- `IbanTest`: fullwidth check digits → `NON_NUMERIC_CHECK_DIGITS`; fullwidth/Arabic-Indic/Devanagari digits in the BBAN → `INVALID_CHARACTER`; leading fullwidth letter and leading Cyrillic look-alike → `INVALID_BOUNDARY_CHARACTER`; lower case and mixed case country codes → `NON_UPPER_CASE_COUNTRY_CODE` (with the message pinned); lower case unknown country code → still `UnknownCountryCode`.
- The lower-case and fullwidth inputs were also added to `rejectionKindInputs`, so the existing "isValidIban and toIbanOrNull agree with invoke" table covers the new rejections on every entry point.

Each of the new IBAN cases parses successfully on `main` and fails on this branch, so they are real regression tests rather than restatements of current behaviour.

## Verification

Run locally on this Linux container:

- `./gradlew jvmTest` — pass (`IbanTest` 89 tests, `Modulo97Test` 27 tests, 0 failures across the suite)
- `./gradlew apiCheck` — pass (both `jvmApiCheck` and `klibApiCheck`, Apple targets inferred)
- `./gradlew ktfmtCheck` — pass
- `./gradlew linuxX64Test` — pass, confirming the behaviour on Kotlin/Native as well as the JVM

Not verifiable here (no Apple toolchain, no Android SDK in the sandbox): Apple-target compilation and tests, and Android-specific tasks. The change is pure `commonMain` with no platform-specific code, and the full matrix runs in `gradle.yml` on this PR.

Closes #136

---
_Generated by [Claude Code](https://claude.ai/code/session_01EX6ziEqPfpw3v38BSQBDg6)_