### PR TITLE
Restrict whitespace leniency in parsing to ASCII space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@
   surface at 1.0. An opt-in normalizer stays possible later as an additive change; going lenient
   first and strict later would not.
 
+* Whitespace leniency in parsing is now limited to the (ASCII 0x20) space (#137). `Iban.toPlain`
+  stripped every character `Char.isWhitespace()` accepts, anywhere in the input, so
+  `Iban("NL91\tABNA 0417164300")` parsed — while the documented contract, and `Modulo97.checksum`
+  one layer down, only ever tolerated 0x20. Tabs, non-breaking spaces and the rest are now left in
+  place and rejected as `Malformed(INVALID_CHARACTER)`, or `Malformed(INVALID_BOUNDARY_CHARACTER)`
+  at the ends of the input. Interior spaces still group (`"NL91 ABNA 0417 1643 00"` parses) and a
+  leading or trailing space is still rejected, both unchanged. Silently dropping a tab from the
+  middle of a bank account identifier treats a paste artifact as intent, and the leniency cannot be
+  narrowed after 1.0 without breaking callers who came to rely on it.
+
+* A wrong-length input that also carries a character outside the IBAN character set is now reported
+  as `Malformed(INVALID_CHARACTER)` rather than `WrongLength` (#137). Such a character adds to the
+  length exactly like a legitimate one, so the old rejection blamed the length for a problem the
+  character caused — and an input of the *correct* length carrying the same character was already
+  reported as `INVALID_CHARACTER` by `Modulo97`. The two paths now agree.
+
 * A known country code written in the wrong case is now reported as
   `Malformed(NON_UPPER_CASE_COUNTRY_CODE)` instead of `UnknownCountryCode` (#136). Lower case input
   such as `"nl91abna0417164300"` was already rejected and stays rejected (`java-iban` parity), but

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ fullwidth `９` or Arabic-Indic `٩` digits are rejected rather than normalized,
 rewriting a bank account identifier hides upstream data corruption. NFKC-normalize user input before
 parsing if your input layer can produce them.
 
+The whitespace leniency is just as narrow: the (ASCII 0x20) space is ignored between the first and
+last character, so both `"NL91ABNA0417164300"` and `"NL91 ABNA 0417 1643 00"` parse, but a leading
+or trailing space is rejected and so is any other whitespace anywhere — a tab or a non-breaking
+space mid-IBAN is a paste artifact, not grouping, and is reported as an invalid character. Trim
+before parsing if your input layer can produce them.
+
 ``` kotlin
     // The primary entry point. Throws IbanParseException on invalid input.
     val iban: Iban = Iban( "NL91ABNA0417164300" )

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -28,7 +28,7 @@ import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
  *
  * @property isInSwiftRegistry whether or not this IBAN data is from the SWIFT IBAN Registry.
  * @property isSEPA whether or not this IBAN is of a SEPA participating country.
- * @property plain the IBAN value, without any white space.
+ * @property plain the IBAN value, without any spaces.
  * @property pretty the IBAN value, with spaces every four characters.
  * @see <a href="https://en.wikipedia.org/wiki/International_Bank_Account_Number">Wikipedia:
  *   International Bank Account Number</a>
@@ -53,7 +53,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
 
     /**
      * Initializing constructor. Validation happens before construction, so this constructor cannot
-     * fail. the IBAN value, without any white space, already validated by the caller.
+     * fail. the IBAN value, without any spaces, already validated by the caller.
      */
     init {
         val countryCode: String = value.substring(0, 2)
@@ -130,6 +130,11 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
          * look-alikes such as fullwidth digits are rejected rather than normalized. Normalize
          * (NFKC) user input before parsing if your input layer can produce them.
          *
+         * The only whitespace tolerated is the (ASCII 0x20) space, and only between the first and
+         * last character: a leading or trailing space is rejected, as is any other whitespace
+         * anywhere, tabs and non-breaking spaces included. Trim before parsing if your input layer
+         * can produce them.
+         *
          * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with
          *   (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
          * @return the parsed and validated IBAN object.
@@ -149,8 +154,8 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         const val SHORTEST_POSSIBLE_IBAN: Int = 5
 
         /**
-         * Wraps an already-validated, whitespace-stripped IBAN string, without paying for
-         * validation a second time.
+         * Wraps an already-validated, space-stripped IBAN string, without paying for validation a
+         * second time.
          */
         internal fun ofValidated(plain: String): Iban = Iban(plain)
 
@@ -192,6 +197,21 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
                         Rejection.UnknownCountryCode(value, countryCode)
                     }
             if (expectedLength != value.length) {
+                // A character the IBAN character set does not contain — a tab, a non-breaking
+                // space, a '$' — adds to the length just like a legitimate character does, so the
+                // length is only the interesting failure once the characters are known to be
+                // legitimate. Correct-length input carrying such a character is caught below, by
+                // Modulo97; without this the two paths would blame different things for the same
+                // mistake. Deliberately not hoisted above the length comparison: the scan is
+                // wasted work for the valid input that is the hot path here.
+                val invalidCharacterIndex: Int = value.indexOfFirst { !it.isAsciiLetterOrDigit() }
+                if (invalidCharacterIndex >= 0) {
+                    return Rejection.Malformed(
+                        value,
+                        Kind.INVALID_CHARACTER,
+                        "Invalid character '${value[invalidCharacterIndex]}' in $value",
+                    )
+                }
                 return Rejection.WrongLength(value, expectedLength, value.length)
             }
             val calculatedChecksum: Int =
@@ -262,13 +282,15 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         }
 
         /**
-         * Removes any spaces contained in the String thereby converting the input into a plain IBAN
+         * Removes the (ASCII 0x20) space characters contained in the input, thereby converting a
+         * pretty printed IBAN into a plain one. Deliberately not [Char.isWhitespace]: only the
+         * space that [addSpaces] emits is grouping, every other whitespace character is a character
+         * an IBAN cannot contain and is left in place for [validate] to reject.
          *
          * @param input possibly pretty printed IBAN
          * @return plain IBAN
          */
-        internal fun toPlain(input: CharSequence): String =
-            input.filter { !it.isWhitespace() }.toString()
+        internal fun toPlain(input: CharSequence): String = input.filter { it != ' ' }.toString()
 
         /**
          * Converts a plain to a pretty printed IBAN

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -20,7 +20,10 @@ package nl.bijdorpstudio.kiban
  * why the input was rejected. Extending [IllegalArgumentException] means callers who only care that
  * parsing failed don't need to catch this type specifically.
  *
- * @property input the offending input, with any (ASCII 0x20) spaces removed.
+ * @property input the offending input, with the (ASCII 0x20) spaces that group a pretty-printed
+ *   IBAN removed. Nothing else is stripped: any other whitespace the input carried is preserved
+ *   here, because it is a character an IBAN cannot contain and is often the very reason for the
+ *   rejection.
  */
 sealed class IbanParseException(
     val input: String,

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -20,7 +20,7 @@ package nl.bijdorpstudio.kiban
  * why the input was rejected. Extending [IllegalArgumentException] means callers who only care that
  * parsing failed don't need to catch this type specifically.
  *
- * @property input the offending input, with any white space removed.
+ * @property input the offending input, with any (ASCII 0x20) spaces removed.
  */
 sealed class IbanParseException(
     val input: String,

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -38,6 +38,24 @@ private val FULLWIDTH_CHECK_DIGITS = VALID_IBAN.replaceRange(2, 4, "０３")
 private val FULLWIDTH_DIGIT_IN_BBAN = VALID_IBAN.replaceRange(8, 9, "０")
 
 /**
+ * Whitespace characters that are not the (ASCII 0x20) space. Parsing tolerates only the space, so
+ * each of these is an invalid character wherever it occurs — the ASCII controls that
+ * [Char.isWhitespace] accepts as well as the Unicode spaces that look like the real thing in a
+ * pasted IBAN.
+ */
+private val nonSpaceWhitespace =
+    listOf(
+        "tab" to '\t',
+        "line feed" to '\n',
+        "carriage return" to '\r',
+        "vertical tab" to '\u000B',
+        "non-breaking space" to '\u00A0',
+        "figure space" to '\u2007',
+        "narrow non-breaking space" to '\u202F',
+        "ideographic space" to '\u3000',
+    )
+
+/**
  * One input per rejection kind the parser distinguishes, plus the valid IBAN. Shared by the tests
  * that assert every entry point agrees on accept/reject and that nothing but [IbanParseException]
  * escapes.
@@ -57,6 +75,8 @@ private val rejectionKindInputs =
         VALID_IBAN.lowercase(),
         FULLWIDTH_CHECK_DIGITS,
         FULLWIDTH_DIGIT_IN_BBAN,
+        VALID_IBAN.replaceRange(4, 4, "\t"),
+        VALID_IBAN.replaceRange(6, 7, "\u00A0"),
     )
 
 /** Miscellaneous tests for the [Iban] class. */
@@ -155,6 +175,62 @@ val IbanTest by testSuite {
                 prop(IbanParseException.Malformed::kind)
                     .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
                 hasMessage("Input begins or ends in an invalid character: $VALID_IBAN ")
+            }
+    }
+
+    test("Invoke should accept the pretty printed form") {
+        assertThat(Iban("NL03 ABNA 0143 2674 69").plain).isEqualTo(VALID_IBAN)
+    }
+
+    // The ASCII space is grouping, every other whitespace character is just a character an IBAN
+    // cannot contain. Inserting one makes the input a character too long and replacing one keeps
+    // the length correct; both have to be blamed on the character, not on the length.
+    for ((label, whitespace) in nonSpaceWhitespace) {
+        test("Invoke should reject an inserted $label") {
+            assertFailure { Iban(VALID_IBAN.replaceRange(4, 4, whitespace.toString())) }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+        }
+
+        test("Invoke should reject a substituted $label") {
+            assertFailure { Iban(VALID_IBAN.replaceRange(6, 7, whitespace.toString())) }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+        }
+
+        test("Invoke should reject a leading $label") {
+            assertFailure { Iban("$whitespace$VALID_IBAN") }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+        }
+
+        test("Invoke should reject a trailing $label") {
+            assertFailure { Iban("$VALID_IBAN$whitespace") }
+                .isInstanceOf<IbanParseException.Malformed>()
+                .prop(IbanParseException.Malformed::kind)
+                .isEqualTo(IbanParseException.Malformed.Kind.INVALID_BOUNDARY_CHARACTER)
+        }
+    }
+
+    test("Invoke should reject the tab that used to be stripped silently") {
+        // The example from #137: before the leniency was narrowed to the ASCII space this parsed,
+        // because toPlain stripped every Unicode whitespace character anywhere in the input.
+        assertFailure { Iban("NL91\tABNA 0417164300") }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .prop(IbanParseException.Malformed::kind)
+            .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+    }
+
+    test("Invoke should reject a wrong length input by its invalid character, not its length") {
+        assertFailure { Iban(VALID_IBAN.replaceRange(4, 4, "_")) }
+            .isInstanceOf<IbanParseException.Malformed>()
+            .all {
+                prop(IbanParseException.Malformed::kind)
+                    .isEqualTo(IbanParseException.Malformed.Kind.INVALID_CHARACTER)
+                hasMessage("Invalid character '_' in ${VALID_IBAN.replaceRange(4, 4, "_")}")
             }
     }
 
@@ -377,6 +453,12 @@ val IbanTest by testSuite {
         )) {
         test("To plain should reduce '$input' to '$plain'") {
             assertThat(Iban.toPlain(input)).isEqualTo(plain)
+        }
+    }
+
+    for ((label, whitespace) in nonSpaceWhitespace) {
+        test("To plain should keep a $label") {
+            assertThat(Iban.toPlain("1234 5${whitespace}678")).isEqualTo("12345${whitespace}678")
         }
     }
 


### PR DESCRIPTION
Takes the recommended option from #137: **restrict to the ASCII space**.

## The problem

`Iban.toPlain` stripped everything `Char.isWhitespace()` accepts, anywhere in the input, so `Iban("NL91\tABNA 0417164300")` parsed — the tab was silently dropped. Both the KDoc on `Iban.invoke` and `Modulo97.checksum` one layer down only ever tolerated the (ASCII 0x20) space, so the three layers disagreed. This cannot be tightened after 1.0 without breaking callers who came to rely on it.

## Changes

* `Iban.toPlain` now strips only `' '`. Every other whitespace character stays in the string and is rejected by `validate` as a character an IBAN cannot contain — `Malformed(INVALID_CHARACTER)` in the interior, `Malformed(INVALID_BOUNDARY_CHARACTER)` at the ends (the boundary check already rejected those, since whitespace is not a letter or digit).

* Interior spaces still group and leading/trailing spaces are still rejected — both unchanged. `Iban("NL91 ABNA 0417 1643 00")` parses exactly as before.

* **Behaviour change beyond the literal ask, flagged deliberately:** a wrong-length input that also carries a character outside the IBAN character set is now `Malformed(INVALID_CHARACTER)` rather than `WrongLength`. Without this, the new rejection for `"NL91\tABNA 0417164300"` would have been `WrongLength(18, 19)` — blaming the length for the character that caused it — while the *same* tab in an input of the correct length was already reported as `INVALID_CHARACTER` by `Modulo97`. Pinning that inconsistency into the test suite right before an API freeze seemed worse than fixing it. The scan sits inside the length-mismatch branch, so valid input (the hot path) does not pay for it, and oversized input is still rejected without `Modulo97`'s `CharArray(2n)` allocation.

* KDoc on `Iban.invoke`, `toPlain`, `ofValidated` and `IbanParseException.input`, plus a README paragraph, now state the contract; CHANGELOG entries under 0.6.0 (unreleased) for both behaviour changes.

No public API signatures changed, so no `apiDump` was needed.

## Tests

`nonSpaceWhitespace` covers tab, LF, CR, vertical tab, NBSP (U+00A0), figure space (U+2007), narrow NBSP (U+202F) and ideographic space (U+3000). For each, four cases: inserted (length becomes wrong), substituted (length stays correct, so `Modulo97` is what catches it), leading, and trailing. Plus the exact example from the issue, the pretty-printed form still parsing, `toPlain` keeping non-space whitespace, and the message assertion for the new `INVALID_CHARACTER` path. The tab and NBSP variants were added to `rejectionKindInputs`, so `isValidIban`/`toIbanOrNull`/`invoke` are checked to agree on them.

## Verification

Run in this Linux sandbox, all passing:

* `./gradlew jvmTest` — 1214 tests
* `./gradlew apiCheck` — both `jvmApiCheck` and `klibApiCheck`, unbuildable Apple targets inferred
* `./gradlew ktfmtCheck`

Not runnable here: Apple-target compilation/tests and the Android-specific tasks (no Xcode, no Android SDK). The change is in `commonMain` with no platform-specific code, and `gradle.yml` covers the full matrix on this PR.

Closes #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8t8yUkyErNL1mCoe5PkVg)_