### PR TITLE
Make IbanParseException subclass constructors internal

### DIFF
--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -47,7 +47,6 @@ public abstract class nl/bijdorpstudio/kiban/IbanParseException : java/lang/Ille
 }
 
 public final class nl/bijdorpstudio/kiban/IbanParseException$Malformed : nl/bijdorpstudio/kiban/IbanParseException {
-	public fun <init> (Ljava/lang/String;Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;Ljava/lang/String;)V
 	public final fun getKind ()Lnl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind;
 }
 
@@ -65,16 +64,13 @@ public final class nl/bijdorpstudio/kiban/IbanParseException$Malformed$Kind : ja
 }
 
 public final class nl/bijdorpstudio/kiban/IbanParseException$UnknownCountryCode : nl/bijdorpstudio/kiban/IbanParseException {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getCountryCode ()Ljava/lang/String;
 }
 
 public final class nl/bijdorpstudio/kiban/IbanParseException$WrongChecksum : nl/bijdorpstudio/kiban/IbanParseException {
-	public fun <init> (Ljava/lang/String;)V
 }
 
 public final class nl/bijdorpstudio/kiban/IbanParseException$WrongLength : nl/bijdorpstudio/kiban/IbanParseException {
-	public fun <init> (Ljava/lang/String;II)V
 	public final fun getActualLength ()I
 	public final fun getExpectedLength ()I
 }

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -43,8 +43,6 @@ sealed class nl.bijdorpstudio.kiban/IbanParseException : kotlin/IllegalArgumentE
         final fun <get-input>(): kotlin/String // nl.bijdorpstudio.kiban/IbanParseException.input.<get-input>|<get-input>(){}[0]
 
     final class Malformed : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.Malformed|null[0]
-        constructor <init>(kotlin/String, nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind, kotlin/String) // nl.bijdorpstudio.kiban/IbanParseException.Malformed.<init>|<init>(kotlin.String;nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind;kotlin.String){}[0]
-
         final val kind // nl.bijdorpstudio.kiban/IbanParseException.Malformed.kind|{}kind[0]
             final fun <get-kind>(): nl.bijdorpstudio.kiban/IbanParseException.Malformed.Kind // nl.bijdorpstudio.kiban/IbanParseException.Malformed.kind.<get-kind>|<get-kind>(){}[0]
 
@@ -66,19 +64,13 @@ sealed class nl.bijdorpstudio.kiban/IbanParseException : kotlin/IllegalArgumentE
     }
 
     final class UnknownCountryCode : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode|null[0]
-        constructor <init>(kotlin/String, kotlin/String) // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode.<init>|<init>(kotlin.String;kotlin.String){}[0]
-
         final val countryCode // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode.countryCode|{}countryCode[0]
             final fun <get-countryCode>(): kotlin/String // nl.bijdorpstudio.kiban/IbanParseException.UnknownCountryCode.countryCode.<get-countryCode>|<get-countryCode>(){}[0]
     }
 
-    final class WrongChecksum : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.WrongChecksum|null[0]
-        constructor <init>(kotlin/String) // nl.bijdorpstudio.kiban/IbanParseException.WrongChecksum.<init>|<init>(kotlin.String){}[0]
-    }
+    final class WrongChecksum : nl.bijdorpstudio.kiban/IbanParseException // nl.bijdorpstudio.kiban/IbanParseException.WrongChecksum|null[0]
 
     final class WrongLength : nl.bijdorpstudio.kiban/IbanParseException { // nl.bijdorpstudio.kiban/IbanParseException.WrongLength|null[0]
-        constructor <init>(kotlin/String, kotlin/Int, kotlin/Int) // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.<init>|<init>(kotlin.String;kotlin.Int;kotlin.Int){}[0]
-
         final val actualLength // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.actualLength|{}actualLength[0]
             final fun <get-actualLength>(): kotlin/Int // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.actualLength.<get-actualLength>|<get-actualLength>(){}[0]
         final val expectedLength // nl.bijdorpstudio.kiban/IbanParseException.WrongLength.expectedLength|{}expectedLength[0]

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -20,6 +20,10 @@ package nl.bijdorpstudio.kiban
  * why the input was rejected. Extending [IllegalArgumentException] means callers who only care that
  * parsing failed don't need to catch this type specifically.
  *
+ * Instances are constructed by kiban only: the subtypes exist to be caught and inspected, not to be
+ * created. Their constructors are internal, so the message wording of a rejection stays the
+ * library's to decide.
+ *
  * @property input the offending input, with the (ASCII 0x20) spaces that group a pretty-printed
  *   IBAN removed. Nothing else is stripped: any other whitespace the input carried is preserved
  *   here, because it is a character an IBAN cannot contain and is often the very reason for the
@@ -36,7 +40,8 @@ sealed class IbanParseException(
      *
      * @property kind the specific structural problem detected.
      */
-    class Malformed(
+    class Malformed
+    internal constructor(
         input: String,
         val kind: Kind,
         message: String,
@@ -79,7 +84,8 @@ sealed class IbanParseException(
      *
      * @property countryCode the two-letter country code that was not recognized.
      */
-    class UnknownCountryCode(
+    class UnknownCountryCode
+    internal constructor(
         input: String,
         val countryCode: String,
     ) : IbanParseException(input, "Unknown country code: $countryCode")
@@ -91,14 +97,16 @@ sealed class IbanParseException(
      * @property expectedLength the length registered for the country code of the input.
      * @property actualLength the length of the input.
      */
-    class WrongLength(
+    class WrongLength
+    internal constructor(
         input: String,
         val expectedLength: Int,
         val actualLength: Int,
     ) : IbanParseException(input, "Wrong length $actualLength for $input expected: $expectedLength")
 
     /** The input is structurally valid, but fails MOD-97 check digit verification. */
-    class WrongChecksum(input: String) : IbanParseException(input, "Wrong check sum for $input")
+    class WrongChecksum internal constructor(input: String) :
+        IbanParseException(input, "Wrong check sum for $input")
 }
 
 /**

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -346,8 +346,12 @@ val IbanTest by testSuite {
 
         assertFailure { Iban(tooLong) }
             .isInstanceOf<IbanParseException.WrongLength>()
-            .prop(IbanParseException.WrongLength::expectedLength)
-            .isEqualTo(18)
+            .all {
+                prop(IbanParseException.WrongLength::input).isEqualTo(tooLong)
+                prop(IbanParseException.WrongLength::expectedLength).isEqualTo(18)
+                prop(IbanParseException.WrongLength::actualLength).isEqualTo(tooLong.length)
+                hasMessage("Wrong length ${tooLong.length} for $tooLong expected: 18")
+            }
     }
 
     test("Invoke should reject checksum failure") {


### PR DESCRIPTION
The constructors of `Malformed`, `UnknownCountryCode`, `WrongLength` and `WrongChecksum` were public in both API dumps. Nobody outside the library has a reason to construct one — they describe *kiban's* rejection of an input — and a public constructor both freezes the parameter lists forever and lets a consumer build `Malformed(input, Kind.EMPTY, "any message")`, bypassing `Rejection.defaultMessage` and inventing rejection wording the library never produces. The sealed parent already prevents external subclassing; this completes the design.

## Changes

- `IbanParseException.Malformed`, `.UnknownCountryCode`, `.WrongLength` and `.WrongChecksum` now declare `internal constructor`.
- KDoc on the sealed parent states that instances are constructed by kiban only, and that the subtypes exist to be caught and inspected.
- Regenerated `library/api/jvm/library.api` and `library/api/library.klib.api` via `apiDump`. The four constructors drop out of both dumps; every property accessor (`input`, `kind`, `countryCode`, `expectedLength`, `actualLength`) and the types themselves stay public, so the read side callers actually use is untouched.
- Strengthened the `Invoke should reject wrong length` test to assert the full public surface of `WrongLength` — `input`, `expectedLength`, `actualLength` and the formatted message. `WrongLength` was the one subtype whose read side was only partly covered, and it is exactly what an internal constructor now guarantees only the library can populate.

Note that a test cannot assert the constructors are *inaccessible*: `commonTest` is an associated (friend) compilation of `commonMain`, so `internal` is visible to it. The API dumps are the enforcement mechanism here, and `apiCheck` runs in CI.

This is binary- and source-breaking, which is why it lands before 1.0.

## Verification

Run locally on Linux:

- `./gradlew jvmTest` — pass, 0 failures (1261 tests across the suite; `IbanTest` 142/142).
- `./gradlew apiCheck` — pass, including both `jvmApiCheck` and `klibApiCheck` (Apple targets inferred).
- `./gradlew ktfmtCheck` — pass.

Not verifiable in this sandbox, per `CLAUDE.md`: Apple-target compilation/tests and Android-specific tasks (no Xcode toolchain, no Android SDK). The klib dump regenerated cleanly with the Apple targets inferred, and `.github/workflows/gradle.yml` covers the full matrix on this PR.

Closes #138


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6AAJyK9jfDDDSi3xpQ4ds)_