### PR TITLE
Add named Iban.parse() with @JvmStatic; verify typed failure access from Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,20 @@
   so `when` statements over `Malformed.kind` that were exhaustive will need a branch for it. An
   unknown country code that also happens to be lower case is still an `UnknownCountryCode`.
 
+**Additions**
+
+* Added `Iban.parse(input)`, a named alias for `Iban(input)`, and made it and `Iban.compose(...)`
+  `@JvmStatic` (#139). `Iban(input)` is `operator fun invoke` on the companion object, and Kotlin is
+  the only language with call syntax for it: Java reads it as `Iban.Companion.invoke(...)` and — as
+  `docs/9-swift-interop-review.md` confirmed against a real `Kiban.xcframework` — Swift reads it as
+  `Iban.companion.invoke(input:)`, which is why `samples/swift-console` avoided it. `parse` carries
+  the same `@Throws(IbanParseException::class)` contract and delegates straight to `invoke`, so
+  there is no second parsing path to keep in step; `@JvmStatic` puts `parse` and `compose` directly
+  on `Iban` for Java callers. The name matches the `java-iban` heritage and reads naturally next to
+  `String.toIban()`. Kotlin callers should keep using `Iban(input)`. Note for anyone still on the
+  0.4.0 API: the returning name is not the returning shape — 0.4.0's `Iban.parse` returned
+  `Result<Iban>`, this one returns `Iban` and throws.
+
 **Documentation**
 
 * Cleaned up KDoc inherited from `java-iban` (#108). The `Iban` class documentation had its

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,7 +17,7 @@ earlier — there are no replacements to reach for beyond what's listed here.
 
 | From | To |
 | --- | --- |
-| `Iban.parse(s)` | `Iban(s)` |
+| `Iban.parse(s)` | `Iban(s)` — 0.6.0 brings the name back, but it returns `Iban` and throws, it does not return `Result<Iban>` |
 | `Iban.parse(s).getOrThrow()` | `Iban(s)` |
 | `Iban.parse(s).getOrNull()` | `s.toIbanOrNull()` |
 | `Iban.parse(s).exceptionOrNull()` | `try { Iban(s) } catch (e: IbanParseException) { … }` |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ programmer-supplied, so a bad one is a contract violation rather than user input
 out-parameter and Swift sees a normal `throws` function instead of the process aborting on an
 unannotated exception.
 
+`Iban(input)` is `operator fun invoke` on the companion object, which only Kotlin has call syntax
+for: Java reads it as `Iban.Companion.invoke(...)` and Swift as `Iban.companion.invoke(input:)`.
+For those callers there is `Iban.parse(input)`, a named alias that parses identically, and
+`Iban.compose(...)` is `@JvmStatic` for the same reason. Kotlin callers should keep using
+`Iban(input)`.
+
 Migrating from `java-iban`, from kiban 0.3.0 and earlier, or from the `Result`-returning 0.4.0 API?
 See [MIGRATION.md](MIGRATION.md).
 

--- a/docs/9-swift-interop-review.md
+++ b/docs/9-swift-interop-review.md
@@ -196,3 +196,20 @@ on `feature/issue-100-strict-throwing-api` via `ios-interop-verify.yml`, buildin
   gets no special Swift-init treatment here, which is why `samples/swift-console` calls the
   top-level `IbanKt.toIban(...)` for its throwing-path demo instead of guessing at `Iban(...)`
   syntax.
+
+## 0.6.0 follow-up: a named `parse`, and a probe for the typed-downcast question (#139)
+
+The `Iban.companion.invoke(input:)` shape above is now avoidable. `Iban.parse(input)` is a named
+alias for `Iban(input)` carrying the same `@Throws(IbanParseException::class)` contract, so Swift
+reads `Iban.companion.parse(input:)` and Java reads `Iban.parse(...)` (`@JvmStatic`, as is
+`Iban.compose(...)`). No `@ObjCName` was added: the default export already yields `parse(input:)`,
+and the one thing a Swift caller would want renamed away — the generated `companion` property —
+isn't something `@ObjCName` can reach. If a run of `ios-interop-verify.yml` shows otherwise, the
+generated header is the evidence to add it on.
+
+`samples/swift-console` now also carries a probe for the question left open above: whether
+`error.userInfo["KotlinException"]` downcasts to the real `IbanParseException` subtype, or only
+yields a description string. It prints the outcome either way rather than asserting one, so a
+`workflow_dispatch` run of `ios-interop-verify.yml` answers it in the job log. **The answer is not
+recorded here yet** — no macOS/Xcode host was available when the probe was written, so it is
+written but unrun. Record it here once that run happens.

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -17,6 +17,7 @@ public final class nl/bijdorpstudio/kiban/Iban : java/lang/Comparable {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Lnl/bijdorpstudio/kiban/Iban;)I
+	public static final fun compose (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBankIdentifier ()Ljava/lang/String;
 	public final fun getBranchIdentifier ()Ljava/lang/String;
@@ -27,12 +28,14 @@ public final class nl/bijdorpstudio/kiban/Iban : java/lang/Comparable {
 	public fun hashCode ()I
 	public final fun isInSwiftRegistry ()Z
 	public final fun isSEPA ()Z
+	public static final fun parse (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class nl/bijdorpstudio/kiban/Iban$Companion {
 	public final fun compose (Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
 	public final fun invoke (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
+	public final fun parse (Ljava/lang/CharSequence;)Lnl/bijdorpstudio/kiban/Iban;
 }
 
 public final class nl/bijdorpstudio/kiban/IbanKt {

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -35,6 +35,7 @@ final class nl.bijdorpstudio.kiban/Iban : kotlin/Comparable<nl.bijdorpstudio.kib
 
         final fun compose(kotlin/CharSequence, kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.compose|compose(kotlin.CharSequence;kotlin.CharSequence){}[0]
         final fun invoke(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.invoke|invoke(kotlin.CharSequence){}[0]
+        final fun parse(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.parse|parse(kotlin.CharSequence){}[0]
     }
 }
 

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -15,6 +15,7 @@
 */
 package nl.bijdorpstudio.kiban
 
+import kotlin.jvm.JvmStatic
 import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
 
 /**
@@ -23,8 +24,9 @@ import nl.bijdorpstudio.kiban.IbanParseException.Malformed.Kind
  * validation is performed, other than matching the length of the IBAN to its country code. Unknown
  * country codes are not supported.
  *
- * Instances can only be obtained through [Iban.invoke] (`Iban(input)`) or [Iban.compose], which
- * validate the input and throw an [IbanParseException] on failure. Construction itself never fails.
+ * Instances can only be obtained through [Iban.invoke] (`Iban(input)`), its named alias
+ * [Iban.parse] for callers outside Kotlin, or [Iban.compose] — all of which validate the input and
+ * throw an [IbanParseException] on failure. Construction itself never fails.
  *
  * @property isInSwiftRegistry whether or not this IBAN data is from the SWIFT IBAN Registry.
  * @property isSEPA whether or not this IBAN is of a SEPA participating country.
@@ -148,6 +150,26 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
             }
 
         /**
+         * Parses the given string into an IBAN object and confirms the check digits. Identical to
+         * [invoke] in every way; it exists because `invoke` has no call syntax outside Kotlin.
+         * `Iban(input)` reads as `Iban.Companion.invoke(...)` from Java and
+         * `Iban.companion.invoke(input:)` from Swift, neither of which is an API anyone would write
+         * on purpose. Kotlin callers should keep using `Iban(input)`.
+         *
+         * The name follows the `java-iban` heritage this library continues, and reads naturally
+         * next to [String.toIban] and [String.toIbanOrNull].
+         *
+         * @param input the input, which can be either plain ("CC11ABCD123...") or formatted with
+         *   (ASCII 0x20) space characters ("CC11 ABCD 123. ..").
+         * @return the parsed and validated IBAN object.
+         * @throws IbanParseException describing why the input was rejected.
+         * @see invoke for the full description of what is and isn't accepted.
+         */
+        @Throws(IbanParseException::class)
+        @JvmStatic
+        fun parse(input: CharSequence): Iban = invoke(input)
+
+        /**
          * The technically shortest possible IBAN. See [CountryCodes.SHORTEST_IBAN_LENGTH] for the
          * shortest valid length.
          */
@@ -240,6 +262,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
          * @throws IbanParseException describing why the parts were rejected.
          */
         @Throws(IbanParseException::class)
+        @JvmStatic
         fun compose(countryCode: CharSequence, bban: CharSequence): Iban {
             val sb =
                 StringBuilder(CountryCodes.LONGEST_IBAN_LENGTH)

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanTest.kt
@@ -18,11 +18,13 @@ package nl.bijdorpstudio.kiban
 import assertk.all
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasClass
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.assertions.prop
@@ -361,6 +363,31 @@ val IbanTest by testSuite {
 
     test("Invoke failure should be an IllegalArgumentException") {
         assertFailure { Iban(INVALID_IBAN) }.isInstanceOf<IllegalArgumentException>()
+    }
+
+    // parse is a named alias for invoke, for the callers whose language has no invoke call syntax:
+    // Java reads Iban.Companion.invoke(...) and Swift Iban.companion.invoke(input:). Nothing about
+    // the parsing may differ between the two, so these assert that the alias agrees with invoke
+    // rather than testing the parser a second time.
+    test("Parse should accept valid input") {
+        assertThat(Iban.parse(VALID_IBAN)).isEqualTo(Iban(VALID_IBAN))
+    }
+
+    test("Parse should accept the pretty printed form") {
+        assertThat(Iban.parse("NL03 ABNA 0143 2674 69").plain).isEqualTo(VALID_IBAN)
+    }
+
+    for (input in rejectionKindInputs) {
+        test("Parse should reject '$input' exactly as invoke does") {
+            val fromInvoke = runCatching { Iban(input) }.exceptionOrNull()
+            assertThat(fromInvoke).isNotNull().isInstanceOf<IbanParseException>()
+
+            assertFailure { Iban.parse(input) }
+                .all {
+                    hasClass(fromInvoke!!::class)
+                    hasMessage(fromInvoke.message)
+                }
+        }
     }
 
     test("Compose should handle correct input") {

--- a/samples/swift-console/Sources/SwiftConsole/main.swift
+++ b/samples/swift-console/Sources/SwiftConsole/main.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Kiban
 
 // Top-level Kotlin extension functions (toIbanOrNull, isValidIban, toIban) are exported as
@@ -25,6 +26,45 @@ do {
     print("unexpected success: \(unexpected.plain)")
 } catch {
     print("toIban(not an iban) failed as expected: \(error)")
+}
+
+// Kotlin's `Iban(input)` is `operator fun invoke` on the companion, which Swift reads as
+// `Iban.companion.invoke(input:)` — so 0.6.0 adds the named alias `Iban.parse(input)` for callers
+// outside Kotlin (#139).
+do {
+    let named = try Iban.companion.parse(input: "NL91 ABNA 0417 1643 00")
+    print("Iban.companion.parse: \(named.plain)")
+} catch {
+    fatalError("expected a valid IBAN, got \(error)")
+}
+
+// The open question left by docs/9-swift-interop-review.md: a caught IbanParseException is
+// reachable as a description string, but does userInfo["KotlinException"] downcast to the real
+// typed exception? This prints the answer either way rather than asserting one, so the run reports
+// what the toolchain actually does.
+do {
+    let unexpected = try Iban.companion.parse(input: "NL91ABNA0417164301")
+    print("unexpected success: \(unexpected.plain)")
+} catch {
+    let kotlinException = (error as NSError).userInfo["KotlinException"]
+    print("KotlinException userInfo entry: \(String(describing: kotlinException))")
+    if let parseFailure = kotlinException as? IbanParseException {
+        print("downcast to IbanParseException: succeeded")
+        switch parseFailure {
+        case let malformed as IbanParseException.Malformed:
+            print("typed access: Malformed, kind \(malformed.kind)")
+        case let wrongLength as IbanParseException.WrongLength:
+            print("typed access: WrongLength, expected \(wrongLength.expectedLength), actual \(wrongLength.actualLength)")
+        case let unknown as IbanParseException.UnknownCountryCode:
+            print("typed access: UnknownCountryCode, \(unknown.countryCode)")
+        case is IbanParseException.WrongChecksum:
+            print("typed access: WrongChecksum")
+        default:
+            print("typed access: unrecognized IbanParseException subtype")
+        }
+    } else {
+        print("downcast to IbanParseException: failed — only the description is reachable")
+    }
 }
 
 print("formatted: \(iban.description)")


### PR DESCRIPTION
`Iban(input)` is `operator fun invoke` on the companion object, and Kotlin is the only language with call syntax for it. Java reads it as `Iban.Companion.invoke(...)`; `docs/9-swift-interop-review.md` confirmed against a real `Kiban.xcframework` that Swift reads it as `Iban.companion.invoke(input:)` — which is why `samples/swift-console` avoided it entirely and used the top-level `IbanKt.toIban(...)` for its throwing-path demo.

## Changes

- **`Iban.parse(input: CharSequence): Iban`** on the companion, delegating straight to `invoke` so there is no second parsing path to keep in step, carrying the same `@Throws(IbanParseException::class)` contract. The name follows the java-iban heritage and reads naturally next to `String.toIban()`. Kotlin callers should keep using `Iban(input)`; the KDoc says so.
- **`@JvmStatic` on `parse` and on `compose`**, so Java reads `Iban.parse(...)` / `Iban.compose(...)` instead of `Iban.Companion.…`. Not added to `invoke` — `Iban.invoke(x)` is not an API anyone would write from Java, and `parse` is the point of this change. The JVM dump shows both as `public static final` on `Iban` while the companion keeps its instance methods, so this is additive on both sides.
- **No `@ObjCName`**, deliberately. The default export already yields `parse(input:)`, and the one thing a Swift caller would want renamed away — the generated `companion` property — is not something `@ObjCName` can reach. Adding an experimental opt-in annotation that changes nothing observable seemed worse than documenting the reasoning; if a real header says otherwise, that's the evidence to add it on. Recorded in `docs/9-swift-interop-review.md`.
- **Regenerated both API dumps** via `apiDump`: `parse` on the companion in the klib dump, plus the two static methods on `Iban` in the JVM dump.
- **Tests**: `parse` accepts a plain and a pretty-printed IBAN, and — over the existing `rejectionKindInputs` set, one input per rejection kind the parser distinguishes — rejects every one of them with the same exception class *and* the same message as `invoke`. That equivalence is what the alias actually promises; re-testing the parser through a second entry point would only duplicate `IbanTest`. 17 new tests.
- **`samples/swift-console`**: calls `Iban.companion.parse(input:)`, and adds a probe for the question `docs/9` left open — whether `error.userInfo["KotlinException"]` downcasts to the real `IbanParseException` subtype, or only yields a description string. It prints the outcome either way rather than asserting one, so the answer lands in the job log without the sample's exit code depending on it.
- README, CHANGELOG and `docs/9-swift-interop-review.md` updated. `MIGRATION.md` gained a caveat on its existing `Iban.parse(s)` row: the name is back, but the *shape* is not — 0.4.0's `parse` returned `Result<Iban>`, this one returns `Iban` and throws. Anyone still on 0.4.0 gets a compile error at the `.getOrThrow()`, not a silent behavior change.

## Verification

Run locally on Linux:

- `./gradlew jvmTest` — pass. The 17 new `IbanTest` cases are in the report by name.
- `./gradlew apiCheck` — pass, both `jvmApiCheck` and `klibApiCheck` (Apple targets inferred), against the regenerated dumps.
- `./gradlew ktfmtCheck` — pass.
- `./gradlew linuxX64Test` — pass, confirming `@JvmStatic` (an optional expectation) compiles away cleanly on Kotlin/Native.
- `./gradlew :samples:jvm-cli:run` — pass.

**Not verified here**, per `CLAUDE.md`: Apple-target compilation/tests and Android-specific tasks — no Xcode toolchain and no Android SDK on this container. In particular the two Swift-facing claims in this PR are unrun:

1. that Swift reads the new function as `Iban.companion.parse(input:)`, and
2. the answer to the `userInfo["KotlinException"]` downcast question.

Both are exactly what the new `samples/swift-console` code exists to answer. **A `workflow_dispatch` run of `ios-interop-verify.yml` on this branch is what closes the second half of #139** — the doc says explicitly that the answer is not recorded yet. `.github/workflows/gradle.yml` covers the full target matrix on this PR.

Closes #139

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtaQXYj2Ras6ssEnUV5DGH)_