### PR TITLE
CountryCodes.knownCountryCodes: narrow Collection to List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@
   so `when` statements over `Malformed.kind` that were exhaustive will need a branch for it. An
   unknown country code that also happens to be lower case is still an `UnknownCountryCode`.
 
+* `CountryCodes.knownCountryCodes` is now typed `List<String>` instead of `Collection<String>`
+  (#140). Alphabetical order was already part of the documented contract, so the type now says so,
+  and callers get indexed access without a copy. The property is also a defensive, immutable copy
+  built once, rather than a fresh `Array.asList()` view per access: the old view shared storage with
+  the library's own reference data, so a `MutableList` cast could `set` an entry and corrupt the
+  registry for the rest of the process — it now rejects every mutation with
+  `UnsupportedOperationException`, on every target rather than only on the JVM. Narrowing the return
+  type is binary-breaking on JVM (`getKnownCountryCodes` changes descriptor), which is why it lands
+  before 1.0; Kotlin source that stored the result in a `Collection<String>` keeps compiling.
+
 **Documentation**
 
 * Cleaned up KDoc inherited from `java-iban` (#108). The `Iban` class documentation had its

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -1,7 +1,7 @@
 public final class nl/bijdorpstudio/kiban/CountryCodes {
 	public static final field INSTANCE Lnl/bijdorpstudio/kiban/CountryCodes;
 	public static final field lastUpdateRevision Ljava/lang/String;
-	public final fun getKnownCountryCodes ()Ljava/util/Collection;
+	public final fun getKnownCountryCodes ()Ljava/util/List;
 	public final fun getLONGEST_IBAN_LENGTH ()I
 	public final fun getLastUpdateDate ()Lkotlin/time/Instant;
 	public final fun getLength (Ljava/lang/CharSequence;)Ljava/lang/Integer;

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -95,7 +95,7 @@ final object nl.bijdorpstudio.kiban/CountryCodes { // nl.bijdorpstudio.kiban/Cou
     final val SHORTEST_IBAN_LENGTH // nl.bijdorpstudio.kiban/CountryCodes.SHORTEST_IBAN_LENGTH|{}SHORTEST_IBAN_LENGTH[0]
         final fun <get-SHORTEST_IBAN_LENGTH>(): kotlin/Int // nl.bijdorpstudio.kiban/CountryCodes.SHORTEST_IBAN_LENGTH.<get-SHORTEST_IBAN_LENGTH>|<get-SHORTEST_IBAN_LENGTH>(){}[0]
     final val knownCountryCodes // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes|{}knownCountryCodes[0]
-        final fun <get-knownCountryCodes>(): kotlin.collections/Collection<kotlin/String> // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes.<get-knownCountryCodes>|<get-knownCountryCodes>(){}[0]
+        final fun <get-knownCountryCodes>(): kotlin.collections/List<kotlin/String> // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes.<get-knownCountryCodes>|<get-knownCountryCodes>(){}[0]
     final val lastUpdateDate // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate|{}lastUpdateDate[0]
         final fun <get-lastUpdateDate>(): kotlin.time/Instant // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate.<get-lastUpdateDate>|<get-lastUpdateDate>(){}[0]
 

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
@@ -138,20 +138,21 @@ object CountryCodes {
         return index > -1 && (COUNTRY_IBAN_LENGTHS[index] and SWIFT) == SWIFT
     }
 
-    val knownCountryCodes: Collection<String>
-        /**
-         * Returns the known country codes.
-         *
-         * @return the collection of known country codes, upper case, in alphabetical order.
-         */
-        get() = COUNTRY_CODES.asList()
+    /**
+     * The known country codes, upper case, in alphabetical order.
+     *
+     * The list is a defensive, immutable copy of the library's reference data: it rejects every
+     * mutation attempt with an [UnsupportedOperationException], including through a cast to
+     * `MutableList`.
+     */
+    val knownCountryCodes: List<String> = buildList { addAll(COUNTRY_CODES) }
 
     /**
      * Returns whether the given string is a known country code.
      *
      * @param countryCode the string to evaluate.
      * @return `true` if `aCountryCode` is a two-letter, uppercase String present in
-     *   [.getKnownCountryCodes].
+     *   [knownCountryCodes].
      */
     fun isKnownCountryCode(countryCode: CharSequence): Boolean {
         return countryCode.length == 2 && indexOf(countryCode.toString()) >= 0

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
@@ -23,38 +23,47 @@ import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
-import de.infix.testBalloon.framework.core.TestConfig
-import de.infix.testBalloon.framework.core.TestPlatform
-import de.infix.testBalloon.framework.core.disable
-import de.infix.testBalloon.framework.core.testPlatform
 import de.infix.testBalloon.framework.core.testSuite
 import kotlin.time.Clock
 import kotlin.time.Instant
 
 /** Some tests for [CountryCodes]. */
 val CountryCodesTest by testSuite {
-    test(
-        "Known country codes should not be editable",
-        // JVM only. There, Collection and MutableCollection erase to the same type, so the cast
-        // is a runtime no-op and `add` reaches the fixed-size list backing `asList()`, which
-        // rejects it with UnsupportedOperationException. Every other target checks the cast and
-        // throws ClassCastException first — the collection is just as immutable there, but this
-        // test asserts the JVM's particular way of saying so.
-        testConfig =
-            if (testPlatform.type == TestPlatform.Type.Jvm) TestConfig else TestConfig.disable(),
-    ) {
+    test("Known country codes should not be editable") {
         // Not meant to be an exhaustive test, just a reminder to keep API consistent if
-        // implementation changes.
+        // implementation changes. The list is built by `buildList`, which rejects mutation on
+        // every target once built — so, unlike the array view it replaced, this holds outside
+        // the JVM too.
         @Suppress("UNCHECKED_CAST")
-        assertFailure { (CountryCodes.knownCountryCodes as MutableCollection<String>).add("ZZ") }
+        assertFailure { (CountryCodes.knownCountryCodes as MutableList<String>).add("ZZ") }
             .isInstanceOf<UnsupportedOperationException>()
+    }
+
+    test("Known country codes should not be editable in place") {
+        // A `set` through the cast is what an array view (`Array.asList()`) would have allowed on
+        // the JVM, corrupting the library's own reference data. The defensive copy rules it out.
+        @Suppress("UNCHECKED_CAST")
+        assertFailure { (CountryCodes.knownCountryCodes as MutableList<String>)[0] = "ZZ" }
+            .isInstanceOf<UnsupportedOperationException>()
+
+        assertThat(CountryCodes.knownCountryCodes.first()).isEqualTo("AD")
     }
 
     test("Known country codes should be in ascending order") {
         val raw = CountryCodes.knownCountryCodes
 
         assertThat(raw.sorted()).isEqualTo(raw)
+    }
+
+    test("Known country codes should be the same instance on every access") {
+        assertThat(CountryCodes.knownCountryCodes).isSameInstanceAs(CountryCodes.knownCountryCodes)
+    }
+
+    test("Known country codes should agree with isKnownCountryCode") {
+        assertThat(CountryCodes.knownCountryCodes.all { CountryCodes.isKnownCountryCode(it) })
+            .isTrue()
     }
 
     test("isKnownCountryCode should return false for empty string") {


### PR DESCRIPTION
`CountryCodes.knownCountryCodes` was typed `Collection<String>` while its KDoc promised "in alphabetical order". Order was already part of the contract, so the type should carry it. Narrowing `Collection` → `List` changes the JVM descriptor of `getKnownCountryCodes`, so it is binary-breaking and has to happen before 1.0.

The issue also asked to consider a defensive copy in place of the `Array.asList()` view, and there turned out to be a concrete reason for one beyond tidiness.

## Changes

- **`val knownCountryCodes: List<String>`**, built once as `buildList { addAll(COUNTRY_CODES) }` instead of a per-access `COUNTRY_CODES.asList()`.

  The old value was an array *view* sharing storage with the library's own reference data. On the JVM it was only fixed-size, not read-only: `Collection` and `MutableCollection` erase to the same type, so a cast succeeded and `set(0, "ZZ")` would have written straight through into `CountryCodesData.COUNTRY_CODES`, corrupting the registry — and `indexOf`'s binary search with it — for the rest of the process. `add` was the only mutation the old view refused. The built list is a copy and rejects every mutation with `UnsupportedOperationException`, so neither reaches the data.

  Building it once also drops the allocation each call site paid to get a view of a static array. (`indexOf` still calls `COUNTRY_CODES.asList()` per lookup; that allocation is #148's scope, not touched here.)

- **KDoc** moved from the getter onto the property, restated as a `List` and stating the immutability guarantee. Also fixed the `[.getKnownCountryCodes]` link in `isKnownCountryCode`'s KDoc — leftover Javadoc syntax that resolves to nothing — to `[knownCountryCodes]`.

- **Regenerated both API dumps** via `apiDump`: `Ljava/util/Collection;` → `Ljava/util/List;` in the JVM dump, `kotlin.collections/Collection<kotlin/String>` → `kotlin.collections/List<…>` in the klib dump. Those two lines are the whole API diff.

- **Tests.** "Known country codes should not be editable" was JVM-only, because on every other target the `MutableCollection` cast threw `ClassCastException` before `add` could run. `buildList`'s result *is* a `MutableList` that refuses mutation, so the cast now succeeds everywhere and the test asserts the same `UnsupportedOperationException` on all targets — the `TestConfig.disable()` guard and its four imports are gone. Three tests added: `set` through the cast fails and leaves the first entry intact (the sharing bug above, pinned), the property returns the same instance on every access (it is a `val`, not a recomputed getter), and every entry it lists is accepted by `isKnownCountryCode`.

- **CHANGELOG** entry under the unreleased breaking changes.

Kotlin source that assigned the result to a `Collection<String>` keeps compiling; only JVM binaries compiled against the old descriptor need a recompile.

## Verification

Run locally on Linux:

- `./gradlew jvmTest` — pass, 1261 tests.
- `./gradlew linuxX64Test` — pass, 1259 tests. This is the one that matters here: it is what confirms the previously-disabled immutability test actually holds on a non-JVM target rather than just compiling.
- `./gradlew apiCheck` — pass (`jvmApiCheck` and `klibApiCheck`, Apple targets inferred) against the regenerated dumps.
- `./gradlew ktfmtCheck` — pass.

**Not verified here**, per `CLAUDE.md`: Apple-target compilation/tests and Android-specific tasks — no Xcode toolchain and no Android SDK on this container. `.github/workflows/gradle.yml` covers the full matrix on this PR. Nothing in this change is Swift-facing beyond the return type, so no `ios-interop-verify.yml` run is needed.

Closes #140

---
_Generated by [Claude Code](https://claude.ai/code/session_015nHvfWzhLhD1M4xJfK64gm)_