### PR TITLE
Constant and accessor naming cleanup before API freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@
   type is binary-breaking on JVM (`getKnownCountryCodes` changes descriptor), which is why it lands
   before 1.0; Kotlin source that stored the result in a `Collection<String>` keeps compiling.
 
+* Constant and accessor names in `CountryCodes` and `Iban` were settled before the API freeze
+  (#141). `Iban.SHORTEST_POSSIBLE_IBAN` is now `Iban.SHORTEST_POSSIBLE_IBAN_LENGTH`,
+  `CountryCodes.SHORTEST_IBAN_LENGTH` / `CountryCodes.LONGEST_IBAN_LENGTH` are now
+  `CountryCodes.shortestIbanLength` / `CountryCodes.longestIbanLength`, and
+  `CountryCodes.getLength(cc)` is now `CountryCodes.ibanLength(cc)`. The three old length names read
+  as if they held an IBAN rather than a number of characters, and `getLength` did not say the length
+  of what. The `CountryCodes` pair also had the Kotlin naming convention inverted — SCREAMING_SNAKE
+  non-`const` `val`s next to a lowerCamel `const val lastUpdateRevision` — which surfaced on the JVM
+  as `getSHORTEST_IBAN_LENGTH()` / `getLONGEST_IBAN_LENGTH()`; lowerCamel makes them
+  `getShortestIbanLength()` / `getLongestIbanLength()` and matches every other member of the object
+  (`lastUpdateDate`, `lastUpdateRevision`, `knownCountryCodes`). `Iban`'s constant stays
+  SCREAMING_SNAKE, which is the convention for a `const val`. Renaming after 1.0 would be breaking,
+  so it happens now; every break is a compile error with a mechanical fix.
+
 **Additions**
 
 * Added `Iban.parse(input)`, a named alias for `Iban(input)`, and made it and `Iban.compose(...)`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,7 +31,7 @@ earlier — there are no replacements to reach for beyond what's listed here.
 | `iban.toPlainString()` | `iban.plain` |
 | `CountryCodes.getBankIdentifier(iban)` | `iban.bankIdentifier` |
 | `CountryCodes.getBranchIdentifier(iban)` | `iban.branchIdentifier` |
-| `CountryCodes.getLengthForCountryCode(cc)` | `CountryCodes.getLength(cc) ?: -1` |
+| `CountryCodes.getLengthForCountryCode(cc)` | `CountryCodes.ibanLength(cc) ?: -1` |
 | `CountryCodes.lastUpdateDateString` | `CountryCodes.lastUpdateDate` |
 
 `runCatching { Iban(s) }` reproduces the old `Result`-returning behaviour exactly, for anyone who wants it back
@@ -116,9 +116,17 @@ ground, and `?:` replaces `orElse`.
 
 | Before | Now |
 | --- | --- |
-| `CountryCodes.getLengthForCountryCode(cc)` → `-1` when unknown | `CountryCodes.getLength(cc)` → `Int?`, `null` when unknown |
+| `CountryCodes.getLengthForCountryCode(cc)` → `-1` when unknown | `CountryCodes.ibanLength(cc)` → `Int?`, `null` when unknown |
 | `CountryCodes.LAST_UPDATE_DATE` / `lastUpdateDateString` | `CountryCodes.lastUpdateDate` → `kotlin.time.Instant` |
 | `CountryCodes.LAST_UPDATE_REV` | `CountryCodes.lastUpdateRevision` |
+| `CountryCodes.SHORTEST_IBAN_LENGTH` *(kiban 0.5.0)* | `CountryCodes.shortestIbanLength` |
+| `CountryCodes.LONGEST_IBAN_LENGTH` *(kiban 0.5.0)* | `CountryCodes.longestIbanLength` |
+| `CountryCodes.getLength(cc)` *(kiban 0.5.0)* | `CountryCodes.ibanLength(cc)` |
+
+The three names marked *(kiban 0.5.0)* were renamed in 0.6.0, together with
+`Iban.SHORTEST_POSSIBLE_IBAN`, which is now `Iban.SHORTEST_POSSIBLE_IBAN_LENGTH`. All four named a
+length without saying so, and the two `CountryCodes` lengths additionally surfaced on the JVM as
+`getSHORTEST_IBAN_LENGTH()` / `getLONGEST_IBAN_LENGTH()`.
 | `CountryCodes.isKnownCountryCode(cc)` | unchanged |
 | `CountryCodes.isSEPACountry(cc)` | unchanged |
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ before parsing if your input layer can produce them.
     Modulo97.calculateCheckDigits( "XX", "X" ) // 72
 
     // Get the expected IBAN length for a country code:
-    val expectedLength: Int? = CountryCodes.getLength( "DK" ) // 18
+    val expectedLength: Int? = CountryCodes.ibanLength( "DK" ) // 18
 
     // Get the Bank Identifier and Branch Identifier:
     val bankId: String? = iban.bankIdentifier

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -2,10 +2,10 @@ public final class nl/bijdorpstudio/kiban/CountryCodes {
 	public static final field INSTANCE Lnl/bijdorpstudio/kiban/CountryCodes;
 	public static final field lastUpdateRevision Ljava/lang/String;
 	public final fun getKnownCountryCodes ()Ljava/util/List;
-	public final fun getLONGEST_IBAN_LENGTH ()I
 	public final fun getLastUpdateDate ()Lkotlin/time/Instant;
-	public final fun getLength (Ljava/lang/CharSequence;)Ljava/lang/Integer;
-	public final fun getSHORTEST_IBAN_LENGTH ()I
+	public final fun getLongestIbanLength ()I
+	public final fun getShortestIbanLength ()I
+	public final fun ibanLength (Ljava/lang/CharSequence;)Ljava/lang/Integer;
 	public final fun isInSwiftRegistry (Ljava/lang/CharSequence;)Z
 	public final fun isKnownCountryCode (Ljava/lang/CharSequence;)Z
 	public final fun isSEPACountry (Ljava/lang/CharSequence;)Z
@@ -13,7 +13,7 @@ public final class nl/bijdorpstudio/kiban/CountryCodes {
 
 public final class nl/bijdorpstudio/kiban/Iban : java/lang/Comparable {
 	public static final field Companion Lnl/bijdorpstudio/kiban/Iban$Companion;
-	public static final field SHORTEST_POSSIBLE_IBAN I
+	public static final field SHORTEST_POSSIBLE_IBAN_LENGTH I
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo (Lnl/bijdorpstudio/kiban/Iban;)I

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -30,8 +30,8 @@ final class nl.bijdorpstudio.kiban/Iban : kotlin/Comparable<nl.bijdorpstudio.kib
     final fun toString(): kotlin/String // nl.bijdorpstudio.kiban/Iban.toString|toString(){}[0]
 
     final object Companion { // nl.bijdorpstudio.kiban/Iban.Companion|null[0]
-        final const val SHORTEST_POSSIBLE_IBAN // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN|{}SHORTEST_POSSIBLE_IBAN[0]
-            final fun <get-SHORTEST_POSSIBLE_IBAN>(): kotlin/Int // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN.<get-SHORTEST_POSSIBLE_IBAN>|<get-SHORTEST_POSSIBLE_IBAN>(){}[0]
+        final const val SHORTEST_POSSIBLE_IBAN_LENGTH // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN_LENGTH|{}SHORTEST_POSSIBLE_IBAN_LENGTH[0]
+            final fun <get-SHORTEST_POSSIBLE_IBAN_LENGTH>(): kotlin/Int // nl.bijdorpstudio.kiban/Iban.Companion.SHORTEST_POSSIBLE_IBAN_LENGTH.<get-SHORTEST_POSSIBLE_IBAN_LENGTH>|<get-SHORTEST_POSSIBLE_IBAN_LENGTH>(){}[0]
 
         final fun compose(kotlin/CharSequence, kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.compose|compose(kotlin.CharSequence;kotlin.CharSequence){}[0]
         final fun invoke(kotlin/CharSequence): nl.bijdorpstudio.kiban/Iban // nl.bijdorpstudio.kiban/Iban.Companion.invoke|invoke(kotlin.CharSequence){}[0]
@@ -83,16 +83,16 @@ final object nl.bijdorpstudio.kiban/CountryCodes { // nl.bijdorpstudio.kiban/Cou
     final const val lastUpdateRevision // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateRevision|{}lastUpdateRevision[0]
         final fun <get-lastUpdateRevision>(): kotlin/String // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateRevision.<get-lastUpdateRevision>|<get-lastUpdateRevision>(){}[0]
 
-    final val LONGEST_IBAN_LENGTH // nl.bijdorpstudio.kiban/CountryCodes.LONGEST_IBAN_LENGTH|{}LONGEST_IBAN_LENGTH[0]
-        final fun <get-LONGEST_IBAN_LENGTH>(): kotlin/Int // nl.bijdorpstudio.kiban/CountryCodes.LONGEST_IBAN_LENGTH.<get-LONGEST_IBAN_LENGTH>|<get-LONGEST_IBAN_LENGTH>(){}[0]
-    final val SHORTEST_IBAN_LENGTH // nl.bijdorpstudio.kiban/CountryCodes.SHORTEST_IBAN_LENGTH|{}SHORTEST_IBAN_LENGTH[0]
-        final fun <get-SHORTEST_IBAN_LENGTH>(): kotlin/Int // nl.bijdorpstudio.kiban/CountryCodes.SHORTEST_IBAN_LENGTH.<get-SHORTEST_IBAN_LENGTH>|<get-SHORTEST_IBAN_LENGTH>(){}[0]
     final val knownCountryCodes // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes|{}knownCountryCodes[0]
         final fun <get-knownCountryCodes>(): kotlin.collections/List<kotlin/String> // nl.bijdorpstudio.kiban/CountryCodes.knownCountryCodes.<get-knownCountryCodes>|<get-knownCountryCodes>(){}[0]
     final val lastUpdateDate // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate|{}lastUpdateDate[0]
         final fun <get-lastUpdateDate>(): kotlin.time/Instant // nl.bijdorpstudio.kiban/CountryCodes.lastUpdateDate.<get-lastUpdateDate>|<get-lastUpdateDate>(){}[0]
+    final val longestIbanLength // nl.bijdorpstudio.kiban/CountryCodes.longestIbanLength|{}longestIbanLength[0]
+        final fun <get-longestIbanLength>(): kotlin/Int // nl.bijdorpstudio.kiban/CountryCodes.longestIbanLength.<get-longestIbanLength>|<get-longestIbanLength>(){}[0]
+    final val shortestIbanLength // nl.bijdorpstudio.kiban/CountryCodes.shortestIbanLength|{}shortestIbanLength[0]
+        final fun <get-shortestIbanLength>(): kotlin/Int // nl.bijdorpstudio.kiban/CountryCodes.shortestIbanLength.<get-shortestIbanLength>|<get-shortestIbanLength>(){}[0]
 
-    final fun getLength(kotlin/CharSequence): kotlin/Int? // nl.bijdorpstudio.kiban/CountryCodes.getLength|getLength(kotlin.CharSequence){}[0]
+    final fun ibanLength(kotlin/CharSequence): kotlin/Int? // nl.bijdorpstudio.kiban/CountryCodes.ibanLength|ibanLength(kotlin.CharSequence){}[0]
     final fun isInSwiftRegistry(kotlin/CharSequence): kotlin/Boolean // nl.bijdorpstudio.kiban/CountryCodes.isInSwiftRegistry|isInSwiftRegistry(kotlin.CharSequence){}[0]
     final fun isKnownCountryCode(kotlin/CharSequence): kotlin/Boolean // nl.bijdorpstudio.kiban/CountryCodes.isKnownCountryCode|isKnownCountryCode(kotlin.CharSequence){}[0]
     final fun isSEPACountry(kotlin/CharSequence): kotlin/Boolean // nl.bijdorpstudio.kiban/CountryCodes.isSEPACountry|isSEPACountry(kotlin.CharSequence){}[0]

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/CountryCodes.kt
@@ -34,11 +34,11 @@ import nl.bijdorpstudio.kiban.CountryCodesData.SWIFT
 
 /** Contains information about IBAN country codes. */
 object CountryCodes {
-    /** The shortest known valid IBAN. */
-    val SHORTEST_IBAN_LENGTH: Int
+    /** The length of the shortest IBAN among the known countries. */
+    val shortestIbanLength: Int
 
-    /** The longest known valid IBAN. */
-    val LONGEST_IBAN_LENGTH: Int
+    /** The length of the longest IBAN among the known countries. */
+    val longestIbanLength: Int
 
     init {
         var min = Int.MAX_VALUE
@@ -52,8 +52,8 @@ object CountryCodes {
                 min = length
             }
         }
-        SHORTEST_IBAN_LENGTH = min
-        LONGEST_IBAN_LENGTH = max
+        shortestIbanLength = min
+        longestIbanLength = max
     }
 
     /**
@@ -108,7 +108,7 @@ object CountryCodes {
      * @return the IBAN length for the given country, or null if the input is not a known,
      *   two-character country code.
      */
-    fun getLength(countryCode: CharSequence): Int? {
+    fun ibanLength(countryCode: CharSequence): Int? {
         val index = indexOf(countryCode.toString())
         if (index > -1) {
             return COUNTRY_IBAN_LENGTHS[index] and REMOVE_METADATA_MASK

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/Iban.kt
@@ -170,10 +170,11 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         fun parse(input: CharSequence): Iban = invoke(input)
 
         /**
-         * The technically shortest possible IBAN. See [CountryCodes.SHORTEST_IBAN_LENGTH] for the
-         * shortest valid length.
+         * The length of the technically shortest possible IBAN. See
+         * [CountryCodes.shortestIbanLength] for the shortest length any known country actually
+         * uses.
          */
-        const val SHORTEST_POSSIBLE_IBAN: Int = 5
+        const val SHORTEST_POSSIBLE_IBAN_LENGTH: Int = 5
 
         /**
          * Wraps an already-validated, space-stripped IBAN string, without paying for validation a
@@ -204,7 +205,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
                 )
             }
             val value = toPlain(input)
-            if (value.length < SHORTEST_POSSIBLE_IBAN) {
+            if (value.length < SHORTEST_POSSIBLE_IBAN_LENGTH) {
                 return Rejection.Malformed(value, Kind.TOO_SHORT)
             }
             if (!(value[2].isAsciiDigit() && value[3].isAsciiDigit())) {
@@ -212,7 +213,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
             }
             val countryCode: String = value.substring(0, 2)
             val expectedLength: Int =
-                CountryCodes.getLength(countryCode)
+                CountryCodes.ibanLength(countryCode)
                     ?: return if (isKnownCountryCodeInWrongCase(countryCode)) {
                         Rejection.Malformed(value, Kind.NON_UPPER_CASE_COUNTRY_CODE)
                     } else {
@@ -265,7 +266,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
         @JvmStatic
         fun compose(countryCode: CharSequence, bban: CharSequence): Iban {
             val sb =
-                StringBuilder(CountryCodes.LONGEST_IBAN_LENGTH)
+                StringBuilder(CountryCodes.longestIbanLength)
                     .append(countryCode)
                     .append("00")
                     .append(bban)
@@ -289,8 +290,8 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
          * normalizes — but it deserves a better diagnosis than "unknown country code", because the
          * country is known.
          *
-         * Only called once the code has already failed the [CountryCodes.getLength] lookup, so both
-         * early returns keep a doomed input from paying for a second binary search.
+         * Only called once the code has already failed the [CountryCodes.ibanLength] lookup, so
+         * both early returns keep a doomed input from paying for a second binary search.
          */
         private fun isKnownCountryCodeInWrongCase(countryCode: String): Boolean {
             val first: Char = countryCode[0]
@@ -299,7 +300,7 @@ class Iban private constructor(internal val value: String) : Comparable<Iban> {
             // An all-upper-case code that failed the lookup is genuinely unknown: upper-casing it
             // cannot change the outcome.
             if (!first.isAsciiLowerCase() && !second.isAsciiLowerCase()) return false
-            return CountryCodes.getLength(
+            return CountryCodes.ibanLength(
                 charArrayOf(first.uppercaseAscii(), second.uppercaseAscii()).concatToString()
             ) != null
         }

--- a/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
+++ b/library/src/commonMain/kotlin/nl/bijdorpstudio/kiban/IbanParseException.kt
@@ -55,7 +55,7 @@ sealed class IbanParseException(
             /** The input begins or ends in a character that cannot occur in an IBAN. */
             INVALID_BOUNDARY_CHARACTER,
 
-            /** The input is shorter than [Iban.SHORTEST_POSSIBLE_IBAN]. */
+            /** The input is shorter than [Iban.SHORTEST_POSSIBLE_IBAN_LENGTH]. */
             TOO_SHORT,
 
             /** The characters at index 2 and 3 are not both ASCII digits. */

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesParameterizedTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesParameterizedTest.kt
@@ -36,7 +36,7 @@ internal val countriesTestData = countryTestData.sortedBy { it.name }
 val CountryCodesParameterizedTest by testSuite {
     for (testData in countriesTestData) {
         test("Length for ${testData.name} should return correct value") {
-            val lengthForCountryCode = CountryCodes.getLength(testData.plain.substring(0, 2)) ?: -1
+            val lengthForCountryCode = CountryCodes.ibanLength(testData.plain.substring(0, 2)) ?: -1
             assertThat(lengthForCountryCode).isEqualTo(testData.plain.length)
         }
     }

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/CountryCodesTest.kt
@@ -20,6 +20,7 @@ import assertk.assertThat
 import assertk.assertions.isBetween
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -78,8 +79,24 @@ val CountryCodesTest by testSuite {
         assertThat(CountryCodes.isKnownCountryCode("NL")).isTrue()
     }
 
-    test("getLength returns null for unknown country code") {
-        assertThat(CountryCodes.getLength("XX")).isNull()
+    test("ibanLength returns null for unknown country code") {
+        assertThat(CountryCodes.ibanLength("XX")).isNull()
+    }
+
+    test("ibanLength returns the registered length for a known country code") {
+        assertThat(CountryCodes.ibanLength("NL")).isEqualTo(18)
+    }
+
+    test("shortest and longest IBAN lengths bound every known country") {
+        val lengths = CountryCodes.knownCountryCodes.map { CountryCodes.ibanLength(it) }
+
+        assertThat(lengths.minOf { it ?: 0 }).isEqualTo(CountryCodes.shortestIbanLength)
+        assertThat(lengths.maxOf { it ?: 0 }).isEqualTo(CountryCodes.longestIbanLength)
+    }
+
+    test("shortest known IBAN length is not shorter than the technical minimum") {
+        assertThat(CountryCodes.shortestIbanLength)
+            .isGreaterThanOrEqualTo(Iban.SHORTEST_POSSIBLE_IBAN_LENGTH)
     }
 
     test("lastUpdateDate should not be null") {

--- a/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
+++ b/library/src/commonTest/kotlin/nl/bijdorpstudio/kiban/IbanInternationalTest.kt
@@ -65,7 +65,7 @@ val IbanInternationalTest by testSuite {
 
     for (testData in countriesTestData) {
         test("Get length for country code should return correct value for ${testData.name}") {
-            val lengthForCountryCode = CountryCodes.getLength(testData.plain.substring(0, 2)) ?: -1
+            val lengthForCountryCode = CountryCodes.ibanLength(testData.plain.substring(0, 2)) ?: -1
             assertThat(lengthForCountryCode).isEqualTo(testData.plain.length)
         }
     }

--- a/samples/jvm-cli/src/main/kotlin/nl/bijdorpstudio/kiban/samples/jvmcli/Main.kt
+++ b/samples/jvm-cli/src/main/kotlin/nl/bijdorpstudio/kiban/samples/jvmcli/Main.kt
@@ -86,8 +86,8 @@ fun main() {
     println("calculateCheckDigits(XX, X): ${Modulo97.calculateCheckDigits("XX", "X")}") // 72
 
     // Get the expected IBAN length for a country code:
-    val expectedLength: Int? = CountryCodes.getLength("DK") // 18
-    println("getLength(DK): $expectedLength")
+    val expectedLength: Int? = CountryCodes.ibanLength("DK") // 18
+    println("ibanLength(DK): $expectedLength")
 
     // Get the Bank Identifier and Branch Identifier:
     println("bankIdentifier: ${iban.bankIdentifier}")

--- a/samples/swift-console/Sources/SwiftConsole/main.swift
+++ b/samples/swift-console/Sources/SwiftConsole/main.swift
@@ -92,7 +92,7 @@ print(
 )
 print("calculateCheckDigits(XX, X): \(Modulo97.shared.calculateCheckDigits(countryCode: "XX", bban: "X"))")
 
-print("getLength(DK): \(String(describing: CountryCodes.shared.getLength(countryCode: "DK")))")
+print("ibanLength(DK): \(String(describing: CountryCodes.shared.ibanLength(countryCode: "DK")))")
 
 print("bankIdentifier: \(String(describing: iban.bankIdentifier))")
 print("branchIdentifier: \(String(describing: iban.branchIdentifier))")


### PR DESCRIPTION
Settles the three names called out in #141 before 1.0 freezes them.

## Renames

| Before | After |
| --- | --- |
| `Iban.SHORTEST_POSSIBLE_IBAN` | `Iban.SHORTEST_POSSIBLE_IBAN_LENGTH` |
| `CountryCodes.SHORTEST_IBAN_LENGTH` | `CountryCodes.shortestIbanLength` |
| `CountryCodes.LONGEST_IBAN_LENGTH` | `CountryCodes.longestIbanLength` |
| `CountryCodes.getLength(cc)` | `CountryCodes.ibanLength(cc)` |

1. **`SHORTEST_POSSIBLE_IBAN`** read as if it held an IBAN string; it holds a number of characters. It stays SCREAMING_SNAKE, which is the convention for a `const val`. `CountryCodes.SHORTEST_IBAN_LENGTH`'s KDoc had the same ambiguity ("The shortest known valid IBAN") and now describes a length.

2. **Style inversion in `CountryCodes`.** The issue offered three ways out (make them `const` via the generator, add `@JvmStatic`, or rename to lowerCamel); this takes the rename. Every other public member of the object is already lowerCamel — `lastUpdateDate`, `lastUpdateRevision`, `knownCountryCodes` — so lowerCamel makes the object internally consistent without touching `scripts/generate_country_data.main.kts` or reverting the deliberate `LAST_UPDATE_REV` → `lastUpdateRevision` rename recorded in MIGRATION.md. It also fixes the Java surface: `getSHORTEST_IBAN_LENGTH()` / `getLONGEST_IBAN_LENGTH()` become `getShortestIbanLength()` / `getLongestIbanLength()`. `@JvmStatic` was not added — it isn't used anywhere else on `CountryCodes`, and adding it here only would be a new inconsistency.

3. **`getLength`** did not say the length of what. `ibanLength(cc)` is the first option the issue lists and reads well on every platform (`CountryCodes.shared.ibanLength(countryCode:)` from Swift).

## Also updated

* `library/api/jvm/library.api` and `library/api/library.klib.api` (via `apiDump`).
* MIGRATION.md — the java-iban rows now point at `ibanLength`, plus a new note listing all four 0.6.0 renames.
* CHANGELOG.md — new entry under 0.6.0 **Breaking changes**. The historical 0.5.0 entries keep the names that actually shipped then.
* README.md, `samples/jvm-cli`, `samples/swift-console`.

## Tests

`CountryCodesTest` gains four cases: `ibanLength` returning `null` for an unknown code (renamed from the existing one), `ibanLength("NL") == 18`, both bounds agreeing with the min/max over every known country code, and `shortestIbanLength >= Iban.SHORTEST_POSSIBLE_IBAN_LENGTH`.

## Verification

Run locally on Linux:

* `./gradlew jvmTest` — pass (the four new cases confirmed present in the jvmTest results).
* `./gradlew apiCheck` — pass after `apiDump`; both dump files are committed and the diff contains only the four renames.
* `./gradlew ktfmtCheck` — pass.
* `./gradlew :samples:jvm-cli:run` — pass, prints `ibanLength(DK): 18`.

Not verified here, per CLAUDE.md: Apple targets and the Android-specific tasks need a toolchain this container lacks. The `samples/swift-console` edit is a one-line rename of a call the Objective-C exporter derives from the Kotlin name; it compiles only on a macOS runner (`ios-interop-verify.yml`), and `gradle.yml`'s full matrix covers the rest once pushed.

Closes #141


---
_Generated by [Claude Code](https://claude.ai/code/session_01BNSZyhFMw74N6wfLA53UqR)_